### PR TITLE
Bootstrap numpy installation in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,43 +2,50 @@
 import sys
 import os
 
-import numpy as np
-
 from setuptools import setup, Extension, find_packages
+from setuptools.command.build_ext import build_ext as _build_ext
 
 debug = '--debug' in sys.argv or '-g' in sys.argv
 
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    use_cython = False
 
-else:
-    use_cython = True
 
-cy_suff = '.pyx' if use_cython else '.c'
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+        try:
+            from Cython.Build import cythonize
+        except ImportError:
+            use_cython = False
+        else:
+            use_cython = True
+        cy_suff = '.pyx' if use_cython else '.c'
 
-cy_files = [
-    ['force_match'],
-    ['utilities', 'blas'],
-    ['utilities', 'math'],
-]
+        cy_files = [
+            ['force_match'],
+            ['utilities', 'blas'],
+            ['utilities', 'math'],
+        ]
 
-macros = []
-if debug:
-    macros.append(('CYTHON_TRACE_NOGIL', '1'))
+        macros = []
+        if debug:
+            macros.append(('CYTHON_TRACE_NOGIL', '1'))
 
-ext_modules = []
-for cy_file in cy_files:
-    ext_modules.append(Extension('.'.join(['sella', *cy_file]),
-                                 [os.path.join('sella', *cy_file) + cy_suff],
-                                 define_macros=macros,
-                                 include_dirs=[np.get_include()]))
+        ext_modules = []
+        for cy_file in cy_files:
+            ext_modules.append(Extension('.'.join(['sella', *cy_file]),
+                                        [os.path.join('sella', *cy_file) + cy_suff],
+                                        define_macros=macros,
+                                        include_dirs=[np.get_include()]))
 
-if use_cython:
-    compdir = dict(linetrace=debug, boundscheck=debug, language_level=3,
-                   wraparound=False, cdivision=True)
-    ext_modules = cythonize(ext_modules, compiler_directives=compdir)
+        if use_cython:
+            compdir = dict(linetrace=debug, boundscheck=debug, language_level=3,
+                        wraparound=False, cdivision=True)
+            ext_modules = cythonize(ext_modules, compiler_directives=compdir)
+        self.ext_modules = ext
 
 with open('README.md', 'r') as f:
     long_description = f.read()
@@ -53,8 +60,6 @@ setup(name='Sella',
       long_description=long_description,
       long_description_content_type='text/markdown',
       packages=find_packages(),
-      ext_modules=ext_modules,
-      include_dirs=[np.get_include()],
       classifiers=['Development Status :: 4 - Beta',
                    'Environment :: Console',
                    'Intended Audience :: Science/Research',
@@ -67,5 +72,7 @@ setup(name='Sella',
                    'Topic :: Scientific/Engineering :: Mathematics',
                    'Topic :: Scientific/Engineering :: Physics'],
       python_requires='>=3.6',
+      cmdclass={'build_ext':build_ext},
+      setup_requires=['numpy'],
       install_requires=install_requires,
       )

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ debug = '--debug' in sys.argv or '-g' in sys.argv
 
 
 class build_ext(_build_ext):
+    # ref: https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
     def finalize_options(self):
         _build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
@@ -73,6 +74,6 @@ setup(name='Sella',
                    'Topic :: Scientific/Engineering :: Physics'],
       python_requires='>=3.6',
       cmdclass={'build_ext':build_ext},
-      setup_requires=['numpy'],
+      setup_requires=['numpy>=1.14'],
       install_requires=install_requires,
       )


### PR DESCRIPTION
In an empty Python environment, `pip install sella` will fail because we are importing `numpy` in `setup.py`.
```
python -m venv sella
source sella/bin/activate
```
Then, `pip install sella` fails with `ModuleNotFoundError: No module named 'numpy'`.

In this PR, we will add `numpy` to setup_requires so that we can install sella even in an empty python environment.
Also, use build_context to import `numpy` lazily.
I referenced following page for implementation.
https://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py