### PR TITLE
Make IRC forward/reverse direction choice deterministic

### DIFF
--- a/sella/optimize/irc.py
+++ b/sella/optimize/irc.py
@@ -77,6 +77,8 @@ class IRC(Optimizer):
             Hw = self.H0 / np.outer(self.sqrtm, self.sqrtm)
             _, vecs = eigh(Hw)
             self.v0ts = self.dx * vecs[:, 0] / self.sqrtm
+            if self.v0ts[np.nonzero(self.v0ts)[0][0]] < 0: 
+                self.v0ts *= -1 #force v0ts to be the direction where the first non-zero component is positive
             self.pescurr = self.pes.curr.copy()
             self.peslast = self.pes.last.copy()
         else:


### PR DESCRIPTION
Define v0ts to be the direction where the first nonzero element is positive. This should prevent non-deterministic direction choice of this eigenvector which makes it difficult to run independent forward and reverse IRCs (as in some cases the reverse and forward IRCs pick different v0ts's causing them to be the same IRC branch). 