### PR TITLE
Add external Hessian function calculation to Sella

### DIFF
--- a/sella/linalg.py
+++ b/sella/linalg.py
@@ -159,9 +159,12 @@ class ApproximateHessian(LinearOperator):
             self.B = None
             self.evals = None
             self.evecs = None
+            self.initialized = False
             return
         elif np.isscalar(target):
             target = target * np.eye(self.dim)
+        else:
+            self.initialized = True
         assert target.shape == self.shape
         self.B = target
         self.evals, self.evecs = eigh(self.B)

--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -152,7 +152,7 @@ class Sella(Optimizer):
         self.xi = 1.
         self.nsteps_per_diag = nsteps_per_diag
         self.nsteps_since_diag = 0
-        self.diag_every_n = diag_every_n
+        self.diag_every_n = np.infty if diag_every_n is None else diag_every_n
 
     def initialize_pes(
         self,

--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -210,7 +210,10 @@ class Sella(Optimizer):
         if not self.initialized:
             self.pes.get_g()
             if self.eig:
-                self.pes.diag(**self.diagkwargs)
+                if self.pes.hessian_function is not None:
+                    self.pes.calculate_hessian()
+                else:
+                    self.pes.diag(**self.diagkwargs)
             self.initialized = True
 
         self.pes.cons.disable_satisfied_inequalities()

--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -2,7 +2,7 @@
 
 import warnings
 from time import localtime, strftime
-from typing import Union
+from typing import Union, Callable, Optional
 
 import numpy as np
 from ase import Atoms
@@ -63,6 +63,8 @@ class Sella(Optimizer):
         append_trajectory: bool = False,
         rs: str = None,
         nsteps_per_diag: int = 3,
+        diag_every_n: Optional[int] = None,
+        hessian_function: Optional[Callable[[Atoms], np.ndarray]] = None,
         **kwargs
     ):
         if order == 0:
@@ -80,7 +82,15 @@ class Sella(Optimizer):
         self.peskwargs = kwargs.copy()
         self.user_internal = internal
         self.initialize_pes(
-            atoms, trajectory, order, eta, constraints, v0, internal, **kwargs
+            atoms,
+            trajectory,
+            order,
+            eta,
+            constraints,
+            v0,
+            internal,
+            hessian_function,
+            **kwargs
         )
 
         if rs is None:
@@ -142,6 +152,7 @@ class Sella(Optimizer):
         self.xi = 1.
         self.nsteps_per_diag = nsteps_per_diag
         self.nsteps_since_diag = 0
+        self.diag_every_n = diag_every_n
 
     def initialize_pes(
         self,
@@ -152,6 +163,7 @@ class Sella(Optimizer):
         constraints: Constraints = None,
         v0: np.ndarray = None,
         internal: Union[bool, Internals] = False,
+        hessian_function: Optional[Callable[[Atoms], np.ndarray]] = None,
         **kwargs
     ):
         if internal:
@@ -176,6 +188,7 @@ class Sella(Optimizer):
                 eta=eta,
                 v0=v0,
                 auto_find_internals=auto_find_internals,
+                hessian_function=hessian_function,
                 **kwargs
             )
         else:
@@ -189,6 +202,7 @@ class Sella(Optimizer):
                 trajectory=trajectory,
                 eta=eta,
                 v0=v0,
+                hessian_function=hessian_function,
                 **kwargs
             )
 
@@ -219,7 +233,9 @@ class Sella(Optimizer):
         s, smag = self._predict_step()
 
         # Determine if we need to call the eigensolver, then step
-        if self.eig and self.nsteps_since_diag >= self.nsteps_per_diag:
+        if self.nsteps_since_diag >= self.diag_every_n:
+            ev = True
+        elif self.eig and self.nsteps_since_diag >= self.nsteps_per_diag:
             if self.pes.H.evals is None:
                 ev = True
             else:
@@ -228,10 +244,12 @@ class Sella(Optimizer):
                                        .evals[:self.ord] > 0).any()
         else:
             ev = False
+
         if ev:
             self.nsteps_since_diag = 0
         else:
             self.nsteps_since_diag += 1
+
         rho = self.pes.kick(s, ev, **self.diagkwargs)
 
         # Check for bad internals, and if found, reset PES object.

--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -214,6 +214,7 @@ class Sella(Optimizer):
                     self.pes.calculate_hessian()
                 else:
                     self.pes.diag(**self.diagkwargs)
+                self.nsteps_since_diag = -1
             self.initialized = True
 
         self.pes.cons.disable_satisfied_inequalities()
@@ -266,6 +267,7 @@ class Sella(Optimizer):
                 constraints=self.constraints,
                 v0=None,  # TODO: use leftmost eigenvector from old H
                 internal=self.user_internal,
+                hessian_function=self.pes.hessian_function,
             )
             self.initialized = False
             self.rho = 1

--- a/sella/peswrapper.py
+++ b/sella/peswrapper.py
@@ -649,7 +649,7 @@ class InternalPES(PES):
         Ured = Ui[:, nnred:]
 
         # Calculate inverse Jacobian in non-redundant space
-        Bnred_inv = VTi[:nnred].T @ np.diag(1 / Si[:nnred]) @ Unred.T
+        Bnred_inv = VTi[:nnred].T @ np.diag(1 / Si[:nnred])
 
         # Convert Cartesian Hessian to non-redundant internal Hessian
         Hcart_corr = Hcart - self.int.hessian().ldot(self.get_g())
@@ -663,8 +663,7 @@ class InternalPES(PES):
         lnred_mean = np.exp(np.log(np.abs(lnred)).mean())
 
         # finish reconstructing redundant internal Hessian
-        P = Ui.T @ Unred
-        return P @ Hnred @ P.T + lnred_mean * Ured @ Ured.T
+        return Unred @ Hnred @ Unred.T + lnred_mean * Ured @ Ured.T
 
     def _convert_internal_hessian_to_cartesian(
         self,

--- a/sella/peswrapper.py
+++ b/sella/peswrapper.py
@@ -641,8 +641,9 @@ class InternalPES(PES):
         self,
         Hcart: np.ndarray,
     ) -> np.ndarray:
+        ncart = 3 * len(self.atoms)
         # Get Jacobian and calculate redundant and non-redundant spaces
-        B = self.int.jacobian()
+        B = self.int.jacobian()[:, :ncart]
         Ui, Si, VTi = np.linalg.svd(B)
         nnred = np.sum(Si > 1e-6)
         Unred = Ui[:, :nnred]
@@ -652,7 +653,8 @@ class InternalPES(PES):
         Bnred_inv = VTi[:nnred].T @ np.diag(1 / Si[:nnred])
 
         # Convert Cartesian Hessian to non-redundant internal Hessian
-        Hcart_corr = Hcart - self.int.hessian().ldot(self.get_g())
+        Hcart_coupled = self.int.hessian().ldot(self.get_g())[:ncart, :ncart]
+        Hcart_corr = Hcart - Hcart_coupled
         Hnred = Bnred_inv.T @ Hcart_corr @ Bnred_inv
 
         # Find eigenvalues of non-redundant internal Hessian


### PR DESCRIPTION
This PR accomplishes a few goals:
1) Provide a means by which to evaluate Hessians using an external program, e.g. exact analytical Hessians
2) Fix the issues we have previously experienced when converting Cartesian Hessians into internal coordinates
3) Add keyword to the Sella optimizer to control how frequently the Hessian is diagonalized/evaluated

Specific changes:
- Add a keyword argument `hessian_function` to the `Sella` class. This optional keyword accepts a function that takes an ASE Atoms object and returns a numpy array containing the Hessian matrix in a Cartesian coordinate basis and in units of eV/Angstrom^2. Providing a value to this keyword overrides the default behavior of constructing the Hessian matrix internally; instead, the Hessian will be calculated with the provided function (and converted to internal coordinates as needed).
- Add a keyword argument `diag_every_n` to the `Sella` class. This optional keyword accepts an integer that indicates how often the Hessian should be evaluated. Providing a value to this keyword overrides the default behavior and forces a Hessian evaluation every `diag_every_n` steps (internal logic may result in the Hessian being evaluated *more* frequently, but never less frequently).
- Adds internal helper functions to the `InternalPES` class `_convert_cartesian_hessian_to_internal` and `_convert_internal_hessian_to_cartesian` which do what the name indicates. I hope to extend this to be used when the internal coordinate system must be reconstructed due to one or more internal coordinates becoming invalid (which would be an improvement over the current behavior of simply throwing out the Hessian entirely).

TO DO:
- ~~Make sure the code runs~~ Done
- ~~Test in Cartesian coordinates~~ Done
- ~~Test in internal coordinates~~
- ~~Test with ML potential from the Head-Gordon group~~