### PR TITLE
Add `keep_going` keyword argument to IRC

### DIFF
--- a/sella/peswrapper.py
+++ b/sella/peswrapper.py
@@ -300,9 +300,6 @@ class PES:
         conv = (fmax1 < fmax) and (cmax1 < cmax)
         return conv, fmax1, cmax1
 
-    def get_W(self):
-        return np.eye(self.dim)
-
     def wrap_dx(self, dx):
         return dx
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from setuptools import setup, Extension, find_packages
 
-VERSION = '2.3.1'
+VERSION = '2.3.2'
 
 debug = '--debug' in sys.argv or '-g' in sys.argv
 


### PR DESCRIPTION
This PR does a couple of things:
1) Adds a `keep_going` keyword argument to `IRC`. When `keep_going=True`, if an IRC inner iteration fails, the IRC optimization will print a warning that the trajectory is no longer accurate, but it will continue with the IRC. This helps when people are using IRC as a way of finding connected minima, but they do not care about the entire IRC trajectory.
2) Fixes a bug where creating an `IRC` instance monkey patches the `get_W` method of the base `PES` class, resulting in all subsequent optimizations using that same `get_W` method.
3) Minor code cleanup and type hinting.