### PR TITLE
Use keyword argument names in `Optimizer` `__init__`

### DIFF
--- a/sella/optimize/irc.py
+++ b/sella/optimize/irc.py
@@ -37,11 +37,11 @@ class IRC(Optimizer):
         Optimizer.__init__(
             self,
             atoms,
-            None,
-            logfile,
-            trajectory,
-            master,
-            force_consistent,
+            restart=None,
+            logfile=logfile,
+            trajectory=trajectory,
+            master=master,
+            force_consistent=force_consistent,
         )
         self.ninner_iter = ninner_iter
         self.irctol = irctol

--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -97,7 +97,7 @@ class Sella(Optimizer):
             rs = 'mis' if internal else 'ras'
         self.rs = get_restricted_step(rs)
         Optimizer.__init__(self, atoms, restart=restart,
-                           logfile=logfile,trajectory=asetraj,
+                           logfile=logfile, trajectory=asetraj,
                            master=master,
                            force_consistent=force_consistent)
 

--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -96,8 +96,10 @@ class Sella(Optimizer):
         if rs is None:
             rs = 'mis' if internal else 'ras'
         self.rs = get_restricted_step(rs)
-        Optimizer.__init__(self, atoms, restart, logfile, asetraj, master,
-                           force_consistent)
+        Optimizer.__init__(self, atoms, restart=restart,
+                           logfile=logfile,trajectory=asetraj,
+                           master=master,
+                           force_consistent=force_consistent)
 
         if delta0 is None:
             delta0 = default['delta0']


### PR DESCRIPTION
Closes #38.

All sella optimizer classes are no longer functional with ASE as of 10 hrs ago due to https://gitlab.com/ase/ase/-/merge_requests/3287. The root cause of the problem is that sella calls the `__init__` of the `Optimizer` class without explicitly specifying keyword argument names (i.e. by supplying all arguments as positional); however, some keyword arguments were just removed from the ASE `Optimizer` class, resulting in a mismatch between the expected and actual arguments being passed. This PR fixes the behavior by writing out the keyword argument names as needed.