### PR TITLE
Remove deprecated `force_consistent` parameter

### DIFF
--- a/sella/optimize/irc.py
+++ b/sella/optimize/irc.py
@@ -24,7 +24,6 @@ class IRC(Optimizer):
         logfile: str = '-',
         trajectory: Optional[Union[str, TrajectoryWriter]] = None,
         master: Optional[bool] = None,
-        force_consistent: bool = False,
         ninner_iter: int = 10,
         irctol: float = 1e-2,
         dx: float = 0.1,
@@ -41,7 +40,6 @@ class IRC(Optimizer):
             logfile=logfile,
             trajectory=trajectory,
             master=master,
-            force_consistent=force_consistent,
         )
         self.ninner_iter = ninner_iter
         self.irctol = irctol

--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -44,7 +44,6 @@ class Sella(Optimizer):
         logfile: str = '-',
         trajectory: Union[str, Trajectory] = None,
         master: bool = None,
-        force_consistent: bool = False,
         delta0: float = None,
         sigma_inc: float = None,
         sigma_dec: float = None,
@@ -98,8 +97,7 @@ class Sella(Optimizer):
         self.rs = get_restricted_step(rs)
         Optimizer.__init__(self, atoms, restart=restart,
                            logfile=logfile, trajectory=asetraj,
-                           master=master,
-                           force_consistent=force_consistent)
+                           master=master)
 
         if delta0 is None:
             delta0 = default['delta0']


### PR DESCRIPTION
Closes #44 (CC @samblau, @juditzador). This PR removes the `force_consistent: bool` parameter since the `force_consistent` parameter was deprecated in ASE and has now been removed. I can confirm that the minimal example in the sella README runs appropriately with this patch.