### PR TITLE
Log accepted trajectory frame IDs

### DIFF
--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -593,36 +593,50 @@ class Sella(Optimizer):
                 result = self.pes.converged(fmax, smax=self.smax)
             _, fmax, cmax, smax_actual = result
             e = self.pes.get_f()
+            traj_id = self.pes.curr.get('traj_id')
             T = strftime("%H:%M:%S", localtime())
             name = self.__class__.__name__
             buf = " " * len(name)
             if self.nsteps == 0:
-                self.logfile.write(buf + "{:>4s} {:>8s} {:>15s} {:>12s} {:>12s} "
-                                   "{:>12s} {:>12s} {:>12s} {:>12s}\n"
-                                   .format("Step", "Time", "Energy", "fmax",
-                                           "smax", "cmax", "rtrust",
-                                           "strust", "rho"))
-            self.logfile.write("{} {:>3d} {:>8s} {:>15.6f} {:>12.4f} {:>12.4f} "
-                               "{:>12.4f} {:>12.4f} {:>12.4f} {:>12.4f}\n"
-                               .format(name, self.nsteps, T, e, fmax, smax_actual,
-                                       cmax, self.delta, self.delta_cell,
-                                       self.rho))
+                header = buf + (
+                    "{:>4s} {:>8s} {:>15s} {:>12s} {:>12s} {:>12s} "
+                    "{:>12s} {:>12s} {:>12s}"
+                ).format("Step", "Time", "Energy", "fmax", "smax", "cmax",
+                         "rtrust", "strust", "rho")
+                if traj_id is not None:
+                    header += " {:>7s}".format("trjid")
+                self.logfile.write(header + "\n")
+            line = (
+                "{} {:>3d} {:>8s} {:>15.6f} {:>12.4f} {:>12.4f} "
+                "{:>12.4f} {:>12.4f} {:>12.4f} {:>12.4f}"
+            ).format(name, self.nsteps, T, e, fmax, smax_actual, cmax,
+                     self.delta, self.delta_cell, self.rho)
+            if traj_id is not None:
+                line += " {:>7d}".format(traj_id)
+            self.logfile.write(line + "\n")
         else:
             result = self._last_converged
             if result is None or len(result) != 3:
                 result = self.pes.converged(self.fmax)
             _, fmax, cmax = result
             e = self.pes.get_f()
+            traj_id = self.pes.curr.get('traj_id')
             T = strftime("%H:%M:%S", localtime())
             name = self.__class__.__name__
             buf = " " * len(name)
             if self.nsteps == 0:
-                self.logfile.write(buf + "{:>4s} {:>8s} {:>15s} {:>12s} {:>12s} "
-                                   "{:>12s} {:>12s}\n"
-                                   .format("Step", "Time", "Energy", "fmax",
-                                           "cmax", "rtrust", "rho"))
-            self.logfile.write("{} {:>3d} {:>8s} {:>15.6f} {:>12.4f} {:>12.4f} "
-                               "{:>12.4f} {:>12.4f}\n"
-                               .format(name, self.nsteps, T, e, fmax, cmax,
-                                       self.delta, self.rho))
+                header = buf + (
+                    "{:>4s} {:>8s} {:>15s} {:>12s} {:>12s} {:>12s} {:>12s}"
+                ).format("Step", "Time", "Energy", "fmax", "cmax", "rtrust",
+                         "rho")
+                if traj_id is not None:
+                    header += " {:>7s}".format("trjid")
+                self.logfile.write(header + "\n")
+            line = (
+                "{} {:>3d} {:>8s} {:>15.6f} {:>12.4f} {:>12.4f} "
+                "{:>12.4f} {:>12.4f}"
+            ).format(name, self.nsteps, T, e, fmax, cmax, self.delta, self.rho)
+            if traj_id is not None:
+                line += " {:>7d}".format(traj_id)
+            self.logfile.write(line + "\n")
         flush_logfile(self.logfile)

--- a/sella/peswrapper.py
+++ b/sella/peswrapper.py
@@ -482,8 +482,10 @@ class PES:
             x=None,
             f=None,
             g=None,
+            traj_id=None,
         )
         self.last = self.curr.copy()
+        self._last_eval_traj_id = None
 
         # Internal coordinate specific things
         self.int = None
@@ -629,6 +631,7 @@ class PES:
         self.curr['x'] = None
         self.curr['f'] = None
         self.curr['g'] = None
+        self.curr['traj_id'] = None
         return H_cols
 
     def _fd_cartesian_hessian(self, delta: float) -> np.ndarray:
@@ -660,6 +663,7 @@ class PES:
         self.curr['x'] = None
         self.curr['f'] = None
         self.curr['g'] = None
+        self.curr['traj_id'] = None
         return (H_cols + H_cols.T) / 2
 
     # Hessian getter/setter
@@ -739,8 +743,11 @@ class PES:
         return result
 
     def write_traj(self):
+        self._last_eval_traj_id = None
         if self.traj is not None:
             self.traj.write()
+            self._last_eval_traj_id = len(self.traj) - 1
+        return self._last_eval_traj_id
 
     def _get_potential_energy_raw(self):
         return self.atoms.get_potential_energy(apply_constraint=False)
@@ -793,9 +800,14 @@ class PES:
 
         if feval:
             f, g = self.eval()
+            # Numerical-Hessian probes call eval() directly, so retain the
+            # frame written for this cached geometry instead of consulting
+            # the trajectory length later when the optimizer logs the step.
+            traj_id = self._last_eval_traj_id
         else:
             f = None
             g = None
+            traj_id = None
 
         if new_point:
             self.last = self.curr.copy()
@@ -804,6 +816,7 @@ class PES:
         self.curr['state_hash'] = state
         self.curr['f'] = f
         self.curr['g'] = g
+        self.curr['traj_id'] = traj_id
         self._update_basis(basis)
         return True
 
@@ -2149,6 +2162,7 @@ class InternalPES(PES):
         return dydt.ravel()
 
     def write_traj(self):
+        self._last_eval_traj_id = None
         if self.traj is not None:
             energy = self.atoms.calc.results['energy']
             forces = np.zeros((len(self.atoms) + len(self.dummies), 3))
@@ -2157,6 +2171,8 @@ class InternalPES(PES):
             atoms_tmp.calc = SinglePointCalculator(atoms_tmp, energy=energy,
                                                    forces=forces)
             self.traj.write(atoms_tmp)
+            self._last_eval_traj_id = len(self.traj) - 1
+        return self._last_eval_traj_id
 
     def _update(self, feval=True):
         if not PES._update(self, feval=feval):
@@ -2360,7 +2376,7 @@ class _CellPESMixin:
 
         self.orig_cell = self.atoms.get_cell().array.copy()
         self.set_H(H, initialized=True)
-        self.curr = dict(x=None, f=None, g=None)
+        self.curr = dict(x=None, f=None, g=None, traj_id=None)
         self.last = self.curr.copy()
         return True
 

--- a/tests/test_trajectory_logging.py
+++ b/tests/test_trajectory_logging.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pytest
+
+from ase import Atoms
+from ase.build import bulk
+from ase.calculators.emt import EMT
+from ase.calculators.lj import LennardJones
+from ase.io import read
+
+from sella import Sella
+
+
+def _read_sella_log(path):
+    lines = path.read_text().splitlines()
+    header = next(line for line in lines if "Step" in line)
+    rows = [line for line in lines if line.startswith("Sella")]
+    return header, rows
+
+
+@pytest.mark.parametrize("internal", [False, True])
+def test_logged_trajectory_ids_are_accepted_geometries(tmp_path, internal):
+    atoms = Atoms("Ar2", positions=[[0, 0, 0], [1.5, 0, 0]])
+    atoms.calc = LennardJones()
+    trajectory = tmp_path / "optimization.traj"
+    logfile = tmp_path / "optimization.log"
+    accepted_positions = []
+
+    opt = Sella(
+        atoms,
+        order=0,
+        internal=internal,
+        trajectory=str(trajectory),
+        logfile=str(logfile),
+        diag_every_n=1,
+        nsteps_per_diag=0,
+    )
+    opt.attach(lambda: accepted_positions.append(atoms.positions.copy()))
+    opt.run(fmax=1e-8, steps=3)
+    opt.close()
+
+    frames = read(trajectory, index=":")
+    header, rows = _read_sella_log(logfile)
+    trajectory_ids = [int(row.split()[-1]) for row in rows]
+
+    assert header.split()[-1] == "trjid"
+    assert len(trajectory_ids) == len(accepted_positions)
+    assert len(frames) > len(accepted_positions)
+    for trajectory_id, positions in zip(trajectory_ids, accepted_positions):
+        np.testing.assert_allclose(frames[trajectory_id].positions, positions)
+
+
+def test_log_omits_trajectory_id_without_trajectory(tmp_path):
+    atoms = Atoms("Ar2", positions=[[0, 0, 0], [1.5, 0, 0]])
+    atoms.calc = LennardJones()
+    logfile = tmp_path / "optimization.log"
+
+    opt = Sella(atoms, order=0, internal=False, logfile=str(logfile))
+    opt.run(fmax=0.0, steps=0)
+    opt.close()
+
+    header, rows = _read_sella_log(logfile)
+    assert "trjid" not in header.split()
+    assert header.split()[-1] == "rho"
+    assert len(rows[0].split()) == len(header.split()) + 1
+
+
+def test_cell_log_includes_trajectory_id(tmp_path):
+    atoms = bulk("Cu", "fcc", a=3.6)
+    atoms.calc = EMT()
+    trajectory = tmp_path / "cell.traj"
+    logfile = tmp_path / "cell.log"
+
+    opt = Sella(
+        atoms,
+        order=0,
+        internal=False,
+        optimize_cell=True,
+        trajectory=str(trajectory),
+        logfile=str(logfile),
+    )
+    opt.run(fmax=0.0, steps=0)
+    opt.close()
+
+    header, rows = _read_sella_log(logfile)
+    assert header.split()[-1] == "trjid"
+    assert int(rows[0].split()[-1]) == 0
+    np.testing.assert_allclose(read(trajectory).cell, atoms.cell)


### PR DESCRIPTION
## Summary

- Add a `trjid` column to Sella logs when a trajectory is active, including cell-optimization logs.
- Track the frame written for the accepted cached PES geometry instead of using `len(trajectory) - 1`. Finite-difference Hessian evaluations also write frames, so the old approach could label a log row with a displaced probe geometry.
- Omit the column when no trajectory exists rather than reporting a misleading frame 0.
- Add regression tests for Cartesian and internal-coordinate optimizations, Hessian probe frames, cell logging, and runs without a trajectory.

The branch is rebuilt as one commit on current `zadorlab/master`.

## Testing

- `342 passed` with the full test suite