### PR TITLE
Fix TRIC bugs and add improper dihedrals for planar centers

### DIFF
--- a/sella/internal.py
+++ b/sella/internal.py
@@ -1339,6 +1339,7 @@ class Internals(BaseInternals):
         self,
         nbond_cart_thr: int = 6,
         max_bonds: int = 20,
+        scale: float = 1.25,
     ) -> None:
         rcov = covalent_radii[self.atoms.numbers]
         nbonds = np.zeros(self.natoms, dtype=np.int32)
@@ -1352,7 +1353,6 @@ class Internals(BaseInternals):
             c10y[j, nbonds[j]] = i
             nbonds[j] += 1
 
-        scale = 1.25
         first_run = True
         while True:
             # use flood fill algorithm to count the number of disconnected
@@ -1368,11 +1368,15 @@ class Internals(BaseInternals):
             # are complete, and we can stop
             if nlabels == 1:
                 break
+
+            # Remove labels from atoms with no bonding partners.
+            # This must happen BEFORE the allow_fragments break, otherwise
+            # single atoms will retain fragment labels and cause rotation ICs
+            # to be incorrectly added to single-atom groups.
+            labels[nbonds == 0] = -1
+
             if self.allow_fragments and not first_run:
                 break
-
-            # remove labels from atoms with no bonding partners
-            labels[nbonds == 0] = -1
 
             for i, j in cwr(range(self.natoms), 2):
                 # do not add a bond between atoms belonging to the same
@@ -1534,6 +1538,7 @@ class Internals(BaseInternals):
                             )
 
     def find_all_dihedrals(self) -> None:
+        # First, find proper dihedrals from angle combinations
         for a1, a2 in combinations(self.internals['angles'], 2):
             try:
                 new = a1 + a2
@@ -1553,11 +1558,82 @@ class Internals(BaseInternals):
             except DuplicateInternalError:
                 continue
 
+        # Second, add improper dihedrals for atoms with 3 or 4 neighbors that don't
+        # have any proper dihedral passing through them. This is needed because:
+        # 1. At planar geometries, bond/angle derivatives vanish for out-of-plane motion
+        # 2. Even starting non-planar, the geometry may planarize during optimization
+        # 3. Improper dihedrals capture the out-of-plane (umbrella) mode
+
+
+        # Note this does add some redundancy to the internals but it also makes it
+        # so that the Jacobian is well-conditioned in the case of planar systems,
+        # such as nitrate.
+        #
+        # We only add impropers when no proper dihedral exists through the atom,
+        # which avoids excessive unnecessary additional internals.
+
+        # First, find which atoms have proper dihedrals through them
+        dihedral_centers = set()
+        for d, a in zip(self.internals['dihedrals'], self._active['dihedrals']):
+            if a:
+                # Positions 1 and 2 are the "central" atoms of a dihedral
+                dihedral_centers.add(int(d.indices[1]))
+                dihedral_centers.add(int(d.indices[2]))
+
+        # Build neighbor list
+        neighbors = [[] for _ in range(self.natoms)]
+        for bond in self.internals['bonds']:
+            i, j = bond.indices
+            if i < self.natoms:
+                neighbors[i].append((int(j), bond.kwargs['ncvecs'][0]))
+            if j < self.natoms:
+                neighbors[j].append((int(i), -bond.kwargs['ncvecs'][0]))
+
+        for center in range(self.natoms):
+            # Consider atoms with 3 or 4 neighbors that lack proper dihedrals.
+            # - 3 neighbors: at planar geometries (e.g., NO3, sp2 carbons), the
+            #   3 angles sum to 360°, creating linear dependency.
+            # - 4 neighbors: at square planar geometries (e.g., Pt(II)), the
+            #   4 cis angles sum to 360°, similar issue. For tetrahedral, the
+            #   improper is redundant but harmless (pseudo-inverse handles it).
+            # - 5+ neighbors: rare, and typically have proper dihedrals anyway.
+            if len(neighbors[center]) not in (3, 4):
+                continue
+
+            # Skip if this atom already has proper dihedrals through it
+            if center in dihedral_centers:
+                continue
+
+            # Add improper dihedral: neighbors[0]-center-neighbors[1]-neighbors[2]
+            n0, ncvec0 = neighbors[center][0]
+            n1, ncvec1 = neighbors[center][1]
+            n2, ncvec2 = neighbors[center][2]
+            # Improper dihedral indices: (n0, center, n1, n2)
+            # The ncvecs connect consecutive atoms in the dihedral
+            imp_ncvecs = (
+                -ncvec0,  # from n0 to center
+                ncvec1,   # from center to n1
+                ncvec2 - ncvec1,  # from n1 to n2
+            )
+            try:
+                self.add_dihedral((n0, center, n1, n2), imp_ncvecs)
+            except DuplicateInternalError:
+                pass
+
     def validate_basis(self) -> None:
         jac = self.jacobian()
         U, S, VT = np.linalg.svd(jac)
         ndeloc = np.sum(S > 1e-8)
-        ndof = 3 * (self.natoms + self.ndummies) - 6
+
+        # If TRICs (translations/rotations) are present, they span the full
+        # 3N DOF. Otherwise, 6 DOF are removed for global translation/rotation.
+        has_trics = (len(self.internals['translations']) > 0 or
+                     len(self.internals['rotations']) > 0)
+        if has_trics:
+            ndof = 3 * (self.natoms + self.ndummies)
+        else:
+            ndof = 3 * (self.natoms + self.ndummies) - 6
+
         if ndeloc != ndof:
             warnings.warn(
                 f'{ndeloc} coords found! Expected {ndof}.'

--- a/tests/internal/test_get_internal.py
+++ b/tests/internal/test_get_internal.py
@@ -1,6 +1,7 @@
 import pytest
 
 import numpy as np
+from ase import Atoms
 from ase.build import molecule
 
 from sella.internal import Internals
@@ -52,3 +53,176 @@ def test_get_internal(name: str) -> None:
         hess_numer[:, i, :] = (jac_plus - jac_minus) / (2 * dx)
     np.testing.assert_allclose(jac, jac_numer, rtol=1e-7, atol=1e-7)
     np.testing.assert_allclose(hess, hess_numer, rtol=1e-7, atol=1e-7)
+
+
+class TestTRICs:
+    """Tests for Translation-Rotation Internal Coordinates (TRICs)."""
+
+    def test_tric_single_atom_fragment(self):
+        """Test TRICs with a single-atom fragment (should not raise assertion).
+
+        This tests the bug fix for the line ordering issue in find_all_bonds()
+        where single atoms would incorrectly get rotation ICs added.
+        """
+        # Bi(NO3)3 cluster from the bug report - Bi is a single atom, NO3 are fragments
+        atoms = Atoms(
+            'BiN3O9',
+            positions=[
+                [-0.168754, 0.103309, -0.601068],   # Bi
+                [-1.452579, 0.996969, 1.671974],    # N
+                [-1.906613, 1.312382, 2.719561],    # O
+                [-0.390479, 0.236458, 1.599985],    # O
+                [-1.916359, 1.339852, 0.548706],    # O
+                [2.088604, 1.559729, 0.184556],     # N
+                [3.081561, 2.106988, 0.537575],     # O
+                [0.991304, 2.160371, -0.042657],    # O
+                [2.046745, 0.279049, -0.004926],    # O
+                [-0.824031, -2.516641, 0.135921],   # N
+                [-1.024602, -3.638619, 0.469313],   # O
+                [0.376482, -2.057305, -0.023988],   # O
+                [-1.745220, -1.672049, -0.097571],  # O
+            ]
+        )
+        # Use scale=1.0 to ensure fragments are detected (not bonded via 1.25 scale)
+        ints = Internals(atoms, allow_fragments=True)
+        # This should not raise an assertion error even though Bi is a single atom
+        ints.find_all_bonds(scale=1.0)
+        ints.find_all_angles()
+        ints.find_all_dihedrals()
+
+        # Should have translations (including for the single Bi atom)
+        assert len(ints.internals['translations']) > 0
+
+        # Rotations should only be for multi-atom fragments (NO3 groups)
+        # Bi should NOT have rotation ICs
+        for rot in ints.internals['rotations']:
+            assert len(rot.indices) >= 2, "Rotation IC added to single atom!"
+
+    def test_tric_scale_parameter(self):
+        """Test that scale parameter affects bond detection."""
+        atoms = Atoms(
+            'BiN3O9',
+            positions=[
+                [-0.168754, 0.103309, -0.601068],   # Bi
+                [-1.452579, 0.996969, 1.671974],    # N
+                [-1.906613, 1.312382, 2.719561],    # O
+                [-0.390479, 0.236458, 1.599985],    # O
+                [-1.916359, 1.339852, 0.548706],    # O
+                [2.088604, 1.559729, 0.184556],     # N
+                [3.081561, 2.106988, 0.537575],     # O
+                [0.991304, 2.160371, -0.042657],    # O
+                [2.046745, 0.279049, -0.004926],    # O
+                [-0.824031, -2.516641, 0.135921],   # N
+                [-1.024602, -3.638619, 0.469313],   # O
+                [0.376482, -2.057305, -0.023988],   # O
+                [-1.745220, -1.672049, -0.097571],  # O
+            ]
+        )
+
+        # With small scale, should have fragments (TRICs added)
+        ints_small = Internals(atoms, allow_fragments=True)
+        ints_small.find_all_bonds(scale=1.0)
+        n_trans_small = len(ints_small.internals['translations'])
+        n_rot_small = len(ints_small.internals['rotations'])
+
+        # With large scale, might connect everything (no TRICs)
+        ints_large = Internals(atoms, allow_fragments=True)
+        ints_large.find_all_bonds(scale=1.5)
+        n_trans_large = len(ints_large.internals['translations'])
+        n_rot_large = len(ints_large.internals['rotations'])
+
+        # Smaller scale should result in more fragments (more TRICs)
+        assert n_trans_small >= n_trans_large
+        assert n_rot_small >= n_rot_large
+
+    def test_tric_two_separate_molecules(self):
+        """Test TRICs with two well-separated molecules."""
+        # Two water molecules far apart - use explicit element list for clarity
+        atoms = Atoms(
+            symbols=['O', 'H', 'H', 'O', 'H', 'H'],
+            positions=[
+                [0.0, 0.0, 0.0],     # O (first molecule)
+                [0.96, 0.0, 0.0],    # H
+                [0.0, 0.96, 0.0],    # H
+                [10.0, 0.0, 0.0],    # O (second molecule, far away)
+                [10.96, 0.0, 0.0],   # H
+                [10.0, 0.96, 0.0],   # H
+            ]
+        )
+
+        ints = Internals(atoms, allow_fragments=True)
+        ints.find_all_bonds()
+        ints.find_all_angles()
+
+        # Should have 2 fragments, so 2 translation sets (6 coords) and 2 rotation sets (6 coords)
+        assert len(ints.internals['translations']) == 6  # 3 per fragment × 2 fragments
+        assert len(ints.internals['rotations']) == 6     # 3 per fragment × 2 fragments
+
+    def test_validate_basis_with_trics(self):
+        """Test that validate_basis correctly calculates DOF with TRICs."""
+        # Two water molecules far apart - use explicit element list for clarity
+        atoms = Atoms(
+            symbols=['O', 'H', 'H', 'O', 'H', 'H'],
+            positions=[
+                [0.0, 0.0, 0.0],     # O (first molecule)
+                [0.96, 0.0, 0.0],    # H
+                [0.0, 0.96, 0.0],    # H
+                [10.0, 0.0, 0.0],    # O (second molecule, far away)
+                [10.96, 0.0, 0.0],   # H
+                [10.0, 0.96, 0.0],   # H
+            ]
+        )
+
+        ints = Internals(atoms, allow_fragments=True)
+        ints.find_all_bonds()
+        ints.find_all_angles()
+
+        # With TRICs, expect 3N = 18 DOF (translations+rotations span full space)
+        # validate_basis should not raise warnings for TRICs
+        import warnings
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ints.validate_basis()
+            # Should not warn if TRIC DOF calculation is correct
+            assert len(w) == 0, f"Unexpected warning: {w[0].message if w else 'none'}"
+
+    def test_tric_optimization_convergence(self):
+        """Test that optimization with TRICs converges (ODE doesn't fail).
+
+        This tests the fix for the ODE convergence issue with ill-conditioned
+        Jacobians that arise from TRICs.
+        """
+        from ase.calculators.lj import LennardJones
+        from sella import Sella
+
+        # Bi(NO3)3 cluster - a real-world TRIC test case
+        atoms = Atoms(
+            'BiN3O9',
+            positions=[
+                [-0.168754, 0.103309, -0.601068],   # Bi
+                [-1.452579, 0.996969, 1.671974],    # N
+                [-1.906613, 1.312382, 2.719561],    # O
+                [-0.390479, 0.236458, 1.599985],    # O
+                [-1.916359, 1.339852, 0.548706],    # O
+                [2.088604, 1.559729, 0.184556],     # N
+                [3.081561, 2.106988, 0.537575],     # O
+                [0.991304, 2.160371, -0.042657],    # O
+                [2.046745, 0.279049, -0.004926],    # O
+                [-0.824031, -2.516641, 0.135921],   # N
+                [-1.024602, -3.638619, 0.469313],   # O
+                [0.376482, -2.057305, -0.023988],   # O
+                [-1.745220, -1.672049, -0.097571],  # O
+            ]
+        )
+        atoms.calc = LennardJones()
+
+        # Use TRICs with small scale to ensure fragments are detected
+        ints = Internals(atoms, allow_fragments=True)
+        ints.find_all_bonds(scale=1.0)
+        ints.find_all_angles()
+        ints.find_all_dihedrals()
+
+        # This should not raise RuntimeError about ODE convergence
+        opt = Sella(atoms, internal=ints)
+        # Just run a few steps to verify ODE works
+        opt.run(fmax=1.0, steps=5)


### PR DESCRIPTION
This addresses issue #32.

TRIC (Translation-Rotation Internal Coordinates) fixes:
- Fix line ordering in find_all_bonds(): move labels[nbonds == 0] = -1 before the allow_fragments break to prevent rotation ICs from being incorrectly added to single-atom fragments
- Add scale parameter to find_all_bonds() (default 1.25) so users can configure the bond detection threshold
- Update validate_basis() to correctly calculate expected DOF when TRICs are present (3N instead of 3N-6)

Improper dihedral detection for ODE convergence:
- Add automatic detection of atoms with 3-4 neighbors that don't have proper dihedrals passing through them
- Create improper dihedrals to capture the out-of-plane (umbrella) mode
- This fixes the "Geometry update ODE is taking too long to converge" error that occurred with ill-conditioned Jacobians at planar geometries
- For tetrahedral geometries (e.g., CH4), the improper is redundant but harmless - the pseudo-inverse handles the extra coordinate gracefully

Add TRIC tests for single-atom fragments, scale parameter, and DOF validation.