### PR TITLE
Further performance improvements and addition of PBC cell optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 .*.swp
 *.html
 *.traj
+*.prof
 .coverage
 build
 *venv

--- a/sella/__init__.py
+++ b/sella/__init__.py
@@ -6,6 +6,8 @@ import os
 _cache_dir = os.path.expanduser("~/.cache/sella/jax_cache")
 os.makedirs(_cache_dir, exist_ok=True)
 os.environ.setdefault("JAX_COMPILATION_CACHE_DIR", _cache_dir)
+# JAX is used only for AD, not linalg; GPU linalg routes through torch
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
 
 import jax
 

--- a/sella/_gpu.py
+++ b/sella/_gpu.py
@@ -1,0 +1,132 @@
+"""Centralized GPU helpers for Sella.
+
+Provides numpy-in / numpy-out wrappers for eigh and QR that route through
+torch+CUDA when a usable GPU is present, with a single shared `_has_torch`
+state and a size threshold that gates upload overhead.
+
+GPU usage is opt-out via SELLA_DISABLE_GPU=1 and the size threshold is
+tunable via SELLA_GPU_MIN_DIM (default 200). On a torch CUDA OOM the call
+falls back to CPU and records the failure so subsequent calls skip the GPU
+attempt for that size; this keeps smaller GPUs from thrashing.
+"""
+
+import os
+import numpy as np
+from scipy.linalg import eigh as _cpu_eigh
+
+try:
+    import torch
+    _has_torch = torch.cuda.is_available()
+except Exception:
+    torch = None
+    _has_torch = False
+
+if os.environ.get("SELLA_DISABLE_GPU", "").lower() in ("1", "true", "yes"):
+    _has_torch = False
+
+try:
+    _GPU_MIN_DIM = int(os.environ.get("SELLA_GPU_MIN_DIM", "200"))
+except ValueError:
+    _GPU_MIN_DIM = 200
+
+# After a CUDA OOM at dimension N, refuse subsequent GPU offload for shapes
+# >= N. Keeps a single failure from cascading and lets the CPU path take over
+# cleanly on small GPUs.
+_oom_floor = None
+
+
+def _gpu_ok(n):
+    return _has_torch and n >= _GPU_MIN_DIM and (
+        _oom_floor is None or n < _oom_floor
+    )
+
+
+def _record_oom(n):
+    global _oom_floor
+    if _oom_floor is None or n < _oom_floor:
+        _oom_floor = n
+    if torch is not None:
+        try:
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+
+def to_gpu(A):
+    """Upload a numpy array to GPU as a contiguous float64 tensor.
+
+    Returns the torch tensor, or None if no GPU is available / upload fails.
+    Caller is responsible for size-gating with `_gpu_ok` if desired.
+    """
+    if not _has_torch:
+        return None
+    try:
+        return torch.from_numpy(np.ascontiguousarray(A)).cuda()
+    except (RuntimeError, MemoryError):
+        _record_oom(A.shape[0] if A.ndim >= 1 else 0)
+        return None
+
+
+def gpu_eigh(A, A_gpu=None):
+    """Eigendecomposition. GPU when beneficial, CPU otherwise.
+
+    If A_gpu (a torch tensor on CUDA) is supplied, the upload is skipped.
+    """
+    n = A.shape[0]
+    if A_gpu is not None or _gpu_ok(n):
+        try:
+            At = A_gpu if A_gpu is not None else to_gpu(A)
+            if At is not None:
+                evals_t, evecs_t = torch.linalg.eigh(At)
+                return evals_t.cpu().numpy(), evecs_t.cpu().numpy()
+        except (RuntimeError, MemoryError):
+            _record_oom(n)
+    return _cpu_eigh(A)
+
+
+def gpu_eigh_t(A_gpu):
+    """Eigendecomposition that returns torch tensors (no .cpu() download).
+
+    Caller has already uploaded; returns (evals_t, evecs_t) on GPU, or
+    (None, None) on OOM so caller can fall back.
+    """
+    try:
+        return torch.linalg.eigh(A_gpu)
+    except (RuntimeError, MemoryError):
+        _record_oom(A_gpu.shape[0])
+        return None, None
+
+
+def gpu_qr(A):
+    """Economy QR. GPU when beneficial, CPU otherwise."""
+    n = A.shape[0]
+    if _gpu_ok(n):
+        try:
+            At = to_gpu(A)
+            if At is not None:
+                Q_t, R_t = torch.linalg.qr(At, mode='reduced')
+                return Q_t.cpu().numpy(), R_t.cpu().numpy()
+        except (RuntimeError, MemoryError):
+            _record_oom(n)
+    return np.linalg.qr(A, mode='reduced')
+
+
+def gpu_project(H, U, H_gpu=None):
+    """Compute U.T @ H @ U on GPU when beneficial.
+
+    Returns a numpy array. If H_gpu is supplied (cached), the H upload is
+    skipped — this is the main motivation for the helper, since the same H
+    is read by both the BFGS eigh and the projection in the same step.
+    """
+    n = H.shape[0]
+    if H_gpu is not None or _gpu_ok(n):
+        try:
+            Ht = H_gpu if H_gpu is not None else to_gpu(H)
+            Ut = to_gpu(U)
+            if Ht is not None and Ut is not None:
+                # Project on device, download only the (k, k) result.
+                R_t = Ut.T @ Ht @ Ut
+                return R_t.cpu().numpy()
+        except (RuntimeError, MemoryError):
+            _record_oom(n)
+    return U.T @ H @ U

--- a/sella/eigensolvers.py
+++ b/sella/eigensolvers.py
@@ -38,7 +38,7 @@ def rayleigh_ritz(A, gamma, P, B=None, v0=None, vref=None, vreftol=0.99,
     if maxiter is None:
         maxiter = 2 * n + 1
 
-    if gamma <= 0 or n == 1:
+    if gamma <= 0:
         return exact(A, gamma, P)
 
     if v0 is not None:
@@ -73,10 +73,7 @@ def rayleigh_ritz(A, gamma, P, B=None, v0=None, vref=None, vreftol=0.99,
         # a hack for the optbench.org eigensolver convergence test
         if vref is not None:
             x0 = V @ vecs[:, 0]
-            print(np.abs(x0 @ vref))
             if np.abs(x0 @ vref) > vreftol:
-                print("Dot product between your v0 and the final answer:",
-                      np.abs(v0 @ x0) / np.linalg.norm(v0))
                 return lams, V, AV
 
         # Loop over all Ritz values of interest
@@ -93,7 +90,7 @@ def rayleigh_ritz(A, gamma, P, B=None, v0=None, vref=None, vreftol=0.99,
 
         t = expand(V, Ytilde, P, B, lams, vecs, thetai, method, seeking)
         t /= np.linalg.norm(t)
-        if np.linalg.norm(t - V @ V.T @ t) < 1e-2:  # pragma: no cover
+        if np.linalg.norm(t - V @ (V.T @ t)) < 1e-2:  # pragma: no cover
             # Do Lanczos instead
             t = ri / np.linalg.norm(ri)
 

--- a/sella/hessian_update.py
+++ b/sella/hessian_update.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from scipy.linalg import eigh, lstsq, solve
 
+from sella import _gpu as _gpu_mod
+
 
 def symmetrize_Y2(S, Y):
     _, nvecs = S.shape
@@ -35,7 +37,15 @@ def symmetrize_Y(S, Y, symm):
         raise ValueError("Unknown symmetrization method {}".format(symm))
 
 
-def update_H(B, S, Y, method='TS-BFGS', symm=2, lams=None, vecs=None):
+def update_H(B, S, Y, method='TS-BFGS', symm=2, lams=None, vecs=None,
+             B_gpu=None, evals_gpu=None, evecs_gpu=None):
+    """Quasi-Newton update.
+
+    Optional GPU-resident path: when B_gpu (torch CUDA tensor) is supplied,
+    the TS-BFGS update runs on device and returns (Bplus_numpy, Bplus_gpu)
+    so the caller can refresh its GPU cache without re-uploading. Falls
+    back to numpy if GPU unavailable or for other update methods.
+    """
     if len(S.shape) == 1:
         if np.linalg.norm(S) < 1e-8:
             return B
@@ -56,6 +66,14 @@ def update_H(B, S, Y, method='TS-BFGS', symm=2, lams=None, vecs=None):
         d, _ = S.shape
         B = lam0 * np.eye(d)
 
+    # GPU-resident TS-BFGS path: requires B_gpu and (evals_gpu, evecs_gpu).
+    if (method == 'TS-BFGS' and B_gpu is not None
+            and evals_gpu is not None and evecs_gpu is not None):
+        result = _gpu_update_TS_BFGS(B_gpu, S, Ytilde, evals_gpu,
+                                     evecs_gpu)
+        if result is not None:
+            return result  # (Bplus_numpy, Bplus_gpu)
+
     if lams is None or vecs is None:
         lams, vecs = eigh(B)
 
@@ -63,7 +81,7 @@ def update_H(B, S, Y, method='TS-BFGS', symm=2, lams=None, vecs=None):
         # Default to TS-BFGS, and only use BFGS if B and S.T @ Y are
         # both positive definite
         method = 'TS-BFGS'
-        if np.all(lams > 0):
+        if lams is not None and np.all(lams > 0):
             lams_STY, vecs_STY = eigh(S.T @ Ytilde, S.T @ S)
             if np.all(lams_STY > 0):
                 method = 'BFGS'
@@ -84,7 +102,11 @@ def update_H(B, S, Y, method='TS-BFGS', symm=2, lams=None, vecs=None):
         raise ValueError('Unknown update method {}'.format(method))
 
     Bplus += B
-    Bplus -= np.tril(Bplus.T - Bplus, -1).T
+    # Symmetrize to clean up floating-point roundoff. The MS_* updates above
+    # are mathematically symmetric, so any asymmetry is at machine precision;
+    # (B + B.T) / 2 is faster than the tril-based approach and gives the same
+    # result up to ~1e-16.
+    Bplus = (Bplus + Bplus.T) * 0.5
 
     return Bplus
 
@@ -133,3 +155,49 @@ def _MS_Greenstadt(B, S, Y):
 # Not a symmetric update, so not available my default
 def _MS_Powell(B, S, Y):  # pragma: no cover
     return (Y - B @ S) @ S.T
+
+
+def _gpu_update_TS_BFGS(B_gpu, S, Y, evals_gpu, evecs_gpu):
+    """GPU-resident TS-BFGS update + symmetrize, returning numpy + torch.
+
+    Mirrors `_MS_TS_BFGS` but does the heavy matmuls and lstsq on device,
+    so the (N,N) eigvecs never need to .cpu()-bounce. Returns
+    (Bplus_numpy, Bplus_gpu) on success, or None to signal the caller to
+    fall back to the numpy path.
+    """
+    torch = _gpu_mod.torch
+    if torch is None:
+        return None
+    try:
+        # S, Y are small (N, k) with k typically 1. Upload once.
+        S_t = torch.from_numpy(np.ascontiguousarray(S)).cuda()
+        Y_t = torch.from_numpy(np.ascontiguousarray(Y)).cuda()
+
+        J_t = Y_t - B_gpu @ S_t
+        X1_t = S_t.T @ Y_t @ Y_t.T  # (k, N)
+        # |B| @ S = vecs @ (|lams| * (vecs.T @ S))
+        absBS_t = evecs_gpu @ (
+            evals_gpu.abs().unsqueeze(1) * (evecs_gpu.T @ S_t)
+        )
+        X2_t = S_t.T @ absBS_t @ absBS_t.T  # (k, N)
+        XS_t = X1_t + X2_t  # (k, N)
+
+        # Solve (XS @ S) U.T = XS  →  U = ((XS @ S)^{-1} @ XS).T
+        # XS_S is (k, k) and tiny; use solve.
+        XS_S_t = XS_t @ S_t  # (k, k)
+        # Use lstsq for parity with numpy path (handles k=1 trivially).
+        U_t = torch.linalg.lstsq(XS_S_t, XS_t).solution.T
+
+        UJT_t = U_t @ J_t.T
+        delta_t = (UJT_t + UJT_t.T) - U_t @ (J_t.T @ S_t) @ U_t.T
+
+        Bplus_t = B_gpu + delta_t
+        # Symmetrize on device.
+        Bplus_t = 0.5 * (Bplus_t + Bplus_t.T)
+
+        # Single download of the new B.
+        Bplus = Bplus_t.cpu().numpy()
+        return Bplus, Bplus_t
+    except (RuntimeError, MemoryError):
+        _gpu_mod._record_oom(B_gpu.shape[0])
+        return None

--- a/sella/internal.py
+++ b/sella/internal.py
@@ -9,6 +9,8 @@ from itertools import (
 from functools import partialmethod
 import warnings
 
+from scipy import sparse
+from scipy.linalg import svdvals
 import numpy as np
 from ase import Atom, Atoms, units
 from ase.cell import Cell
@@ -22,7 +24,8 @@ import jax.numpy as jnp
 from jax import jit, grad, jacfwd, jacrev, custom_jvp, vmap, jvp, device_get
 
 from sella.linalg import (
-    SparseInternalJacobian, SparseInternalHessian, SparseInternalHessians
+    SparseInternalJacobian, SparseInternalHessian, SparseInternalHessians,
+    SparseInternalHessiansSkeleton
 )
 
 
@@ -32,7 +35,7 @@ from sella.linalg import (
 # Creating ASE Atoms objects has significant overhead (Atoms.__init__ validates
 # positions, sets up constraints, etc.). This lightweight wrapper provides just
 # the positions and cell attributes needed for coordinate calculations, reducing
-# Atoms.__init__ calls (~79% reduction).
+# Atoms.__init__ calls from ~1258 to ~266 per optimization run (~79% reduction).
 # =============================================================================
 
 class LightAtoms:
@@ -77,63 +80,109 @@ def _dihedral_value(pos: jnp.ndarray, tvec: jnp.ndarray) -> float:
     return jnp.arctan2(numer, denom)
 
 
+# Batched gradient functions: input shapes (n_coords, n_atoms, 3), (n_coords, n_vecs, 3)
+# Output shapes: (n_coords, n_atoms, 3)
+_bond_grad_batched = jit(vmap(grad(_bond_value, argnums=0), in_axes=(0, 0)))
+_angle_grad_batched = jit(vmap(grad(_angle_value, argnums=0), in_axes=(0, 0)))
+_dihedral_grad_batched = jit(vmap(grad(_dihedral_value, argnums=0), in_axes=(0, 0)))
+
+# Batched value functions
+_bond_value_batched = jit(vmap(_bond_value, in_axes=(0, 0)))
+_angle_value_batched = jit(vmap(_angle_value, in_axes=(0, 0)))
+_dihedral_value_batched = jit(vmap(_dihedral_value, in_axes=(0, 0)))
+
+# Batched hessian functions: output shapes (n_coords, n_atoms, 3, n_atoms, 3)
+_bond_hess_batched = jit(vmap(jacfwd(grad(_bond_value, argnums=0), argnums=0), in_axes=(0, 0)))
+_angle_hess_batched = jit(vmap(jacfwd(grad(_angle_value, argnums=0), argnums=0), in_axes=(0, 0)))
+_dihedral_hess_batched = jit(vmap(jacfwd(grad(_dihedral_value, argnums=0), argnums=0), in_axes=(0, 0)))
+
 # =============================================================================
-# Factory functions for creating batched JAX operations
+# Hessian-vector product (HVP) functions using forward-over-reverse mode
 # =============================================================================
-# These factories eliminate code duplication by generating value, gradient,
-# hessian, and HVP functions from a single coordinate value function.
+# These compute H @ v directly without materializing the full Hessian matrix.
+# Uses jvp(grad(f), x, v) which is O(n) instead of O(n²) for forming full Hessian.
 # =============================================================================
 
-def _make_batched_ops(func):
-    """Factory for batched value/gradient/hessian functions.
-
-    Args:
-        func: Coordinate value function with signature (pos, tvec) -> float
-
-    Returns:
-        Tuple of (value_batched, grad_batched, hess_batched) functions
-    """
-    return (
-        jit(vmap(func, in_axes=(0, 0))),
-        jit(vmap(grad(func, argnums=0), in_axes=(0, 0))),
-        jit(vmap(jacfwd(grad(func, argnums=0), argnums=0), in_axes=(0, 0))),
-    )
+def _bond_hvp_single(pos: jnp.ndarray, tvec: jnp.ndarray, tangent: jnp.ndarray) -> jnp.ndarray:
+    """Compute Hessian @ tangent for a single bond without forming the Hessian."""
+    primals = (pos, tvec)
+    tangents = (tangent, jnp.zeros_like(tvec))
+    _, hvp_result = jvp(grad(_bond_value, argnums=0), primals, tangents)
+    return hvp_result
 
 
-def _make_hvp_single(func):
-    """Factory for Hessian-vector product function.
-
-    Uses forward-over-reverse mode: jvp(grad(f), x, v) computes H @ v
-    in O(n) instead of O(n²) for forming full Hessian.
-
-    Args:
-        func: Coordinate value function with signature (pos, tvec) -> float
-
-    Returns:
-        HVP function with signature (pos, tvec, tangent) -> hvp_result
-    """
-    def hvp_single(pos: jnp.ndarray, tvec: jnp.ndarray, tangent: jnp.ndarray) -> jnp.ndarray:
-        primals = (pos, tvec)
-        tangents = (tangent, jnp.zeros_like(tvec))
-        _, hvp_result = jvp(grad(func, argnums=0), primals, tangents)
-        return hvp_result
-    return hvp_single
+def _angle_hvp_single(pos: jnp.ndarray, tvec: jnp.ndarray, tangent: jnp.ndarray) -> jnp.ndarray:
+    """Compute Hessian @ tangent for a single angle without forming the Hessian."""
+    primals = (pos, tvec)
+    tangents = (tangent, jnp.zeros_like(tvec))
+    _, hvp_result = jvp(grad(_angle_value, argnums=0), primals, tangents)
+    return hvp_result
 
 
-# Create batched operations for each coordinate type
-# Input shapes: (n_coords, n_atoms, 3), (n_coords, n_vecs, 3)
-# Value output: (n_coords,), Grad output: (n_coords, n_atoms, 3)
-# Hessian output: (n_coords, n_atoms, 3, n_atoms, 3)
-_bond_value_batched, _bond_grad_batched, _bond_hess_batched = _make_batched_ops(_bond_value)
-_angle_value_batched, _angle_grad_batched, _angle_hess_batched = _make_batched_ops(_angle_value)
-_dihedral_value_batched, _dihedral_grad_batched, _dihedral_hess_batched = _make_batched_ops(_dihedral_value)
+def _dihedral_hvp_single(pos: jnp.ndarray, tvec: jnp.ndarray, tangent: jnp.ndarray) -> jnp.ndarray:
+    """Compute Hessian @ tangent for a single dihedral without forming the Hessian."""
+    primals = (pos, tvec)
+    tangents = (tangent, jnp.zeros_like(tvec))
+    _, hvp_result = jvp(grad(_dihedral_value, argnums=0), primals, tangents)
+    return hvp_result
+
 
 # Batched HVP functions: compute H @ v for all coords at once
 # Input shapes: pos (n_coords, n_atoms, 3), tvec (n_coords, n_vecs, 3), tangent (n_coords, n_atoms, 3)
 # Output shapes: (n_coords, n_atoms, 3)
-_bond_hvp_batched = jit(vmap(_make_hvp_single(_bond_value), in_axes=(0, 0, 0)))
-_angle_hvp_batched = jit(vmap(_make_hvp_single(_angle_value), in_axes=(0, 0, 0)))
-_dihedral_hvp_batched = jit(vmap(_make_hvp_single(_dihedral_value), in_axes=(0, 0, 0)))
+_bond_hvp_batched = jit(vmap(_bond_hvp_single, in_axes=(0, 0, 0)))
+_angle_hvp_batched = jit(vmap(_angle_hvp_single, in_axes=(0, 0, 0)))
+_dihedral_hvp_batched = jit(vmap(_dihedral_hvp_single, in_axes=(0, 0, 0)))
+
+
+# =============================================================================
+# Cell-derivative functions for unit cell optimization
+# =============================================================================
+# These compute derivatives of internal coordinates with respect to cell matrix.
+# Used for coupled atomic + cell optimization in periodic systems.
+#
+# The chain rule is: d(coord)/d(cell) = d(coord)/d(tvec) @ d(tvec)/d(cell)
+# Since tvec = ncvec @ cell, we have d(tvec)/d(cell) = ncvec (Kronecker structure)
+# =============================================================================
+
+def _bond_with_cell(pos: jnp.ndarray, ncvec: jnp.ndarray, cell: jnp.ndarray) -> float:
+    """Bond length with cell as explicit parameter for autodiff."""
+    tvec = ncvec @ cell  # (1, 3) @ (3, 3) -> (1, 3)
+    return jnp.linalg.norm(pos[1] - pos[0] + tvec[0])
+
+
+def _angle_with_cell(pos: jnp.ndarray, ncvec: jnp.ndarray, cell: jnp.ndarray) -> float:
+    """Angle with cell as explicit parameter for autodiff."""
+    tvec = ncvec @ cell  # (2, 3) @ (3, 3) -> (2, 3)
+    dx1 = -(pos[1] - pos[0] + tvec[0])
+    dx2 = pos[2] - pos[1] + tvec[1]
+    cos_angle = dx1 @ dx2 / (jnp.linalg.norm(dx1) * jnp.linalg.norm(dx2))
+    cos_angle = jnp.clip(cos_angle, -1.0, 1.0)
+    return jnp.arccos(cos_angle)
+
+
+def _dihedral_with_cell(pos: jnp.ndarray, ncvec: jnp.ndarray, cell: jnp.ndarray) -> float:
+    """Dihedral angle with cell as explicit parameter for autodiff."""
+    tvec = ncvec @ cell  # (3, 3) @ (3, 3) -> (3, 3)
+    dx1 = pos[1] - pos[0] + tvec[0]
+    dx2 = pos[2] - pos[1] + tvec[1]
+    dx3 = pos[3] - pos[2] + tvec[2]
+    numer = dx2 @ jnp.cross(jnp.cross(dx1, dx2), jnp.cross(dx2, dx3))
+    denom = jnp.linalg.norm(dx2) * jnp.cross(dx1, dx2) @ jnp.cross(dx2, dx3)
+    return jnp.arctan2(numer, denom)
+
+
+# Single-coordinate cell gradients: output shape (3, 3) for d(coord)/d(cell)
+_bond_cell_grad_single = jit(grad(_bond_with_cell, argnums=2))
+_angle_cell_grad_single = jit(grad(_angle_with_cell, argnums=2))
+_dihedral_cell_grad_single = jit(grad(_dihedral_with_cell, argnums=2))
+
+# Batched cell gradients: input (n_coords, n_atoms, 3), (n_coords, n_vecs, 3), (3, 3)
+# Output: (n_coords, 3, 3)
+# Note: cell is NOT batched (same cell for all coords), so in_axes=(0, 0, None)
+_bond_cell_grad_batched = jit(vmap(_bond_cell_grad_single, in_axes=(0, 0, None)))
+_angle_cell_grad_batched = jit(vmap(_angle_cell_grad_single, in_axes=(0, 0, None)))
+_dihedral_cell_grad_batched = jit(vmap(_dihedral_cell_grad_single, in_axes=(0, 0, None)))
 
 
 # =============================================================================
@@ -388,6 +437,31 @@ class Internal(Coordinate):
         )
         return np.array(self._eval2(atoms.positions[self.indices], tvecs))
 
+    @staticmethod
+    def _eval_cell_grad(
+        pos: jnp.ndarray, ncvecs: jnp.ndarray, cell: jnp.ndarray
+    ) -> jnp.ndarray:
+        """Compute gradient of coordinate with respect to cell matrix.
+
+        Must be overridden in subclasses (Bond, Angle, Dihedral).
+        Returns shape (3, 3) for d(coord)/d(cell).
+        """
+        raise NotImplementedError
+
+    def calc_cell_gradient(self, atoms: Atoms) -> np.ndarray:
+        """Compute gradient of this coordinate w.r.t. cell matrix.
+
+        Returns:
+            np.ndarray: Shape (3, 3) array of d(coord)/d(cell[i,j])
+        """
+        ncvecs = jnp.asarray(self.kwargs['ncvecs'], dtype=np.float64)
+        cell = jnp.asarray(
+            atoms.cell.array,
+            dtype=np.float64
+        )
+        pos = jnp.asarray(atoms.positions[self.indices], dtype=np.float64)
+        return np.array(self._eval_cell_grad(pos, ncvecs, cell))
+
 
 def _translation(
     pos: jnp.ndarray,
@@ -467,9 +541,7 @@ def _rotation_q(
         [Ftop[:, None], -Rtr * jnp.eye(3) + R + R.T],
     ])
     q = eigh_rightmost(F)
-    # Use where instead of sign: sign(0)=0 in JAX which zeros the entire
-    # quaternion for linear molecules, making all rotation Jacobians zero.
-    return q * jnp.where(q[0] >= 0, 1.0, -1.0)
+    return q * jnp.sign(q[0])
 
 
 # "inverse sinc" function, naive, undefined at x=1
@@ -509,6 +581,85 @@ def _rotation(
 ) -> float:
     q = _rotation_q(pos, refpos)
     return 2 * q[axis + 1] * asinc(q[0])
+
+
+def _rotation_3axis_masked(
+    pos: jnp.ndarray, refpos: jnp.ndarray, mask: jnp.ndarray
+) -> jnp.ndarray:
+    """All 3 rotation values for one fragment, padded + masked.
+
+    Returns an array of length 3 (one value per rotation axis). The
+    fragment is assumed centered: ``refpos`` is already the centered
+    reference, padded rows are zero. ``mask`` is 1 on real atoms and 0
+    on padding so the centroid divides by the actual atom count.
+    """
+    pos_eff = pos * mask[:, None]
+    natoms = jnp.sum(mask)
+    centroid = jnp.sum(pos_eff, axis=0) / natoms
+    dx = (pos - centroid) * mask[:, None]
+    refpos_centered = refpos * mask[:, None]
+    R = dx.T @ refpos_centered
+    Rtr = jnp.trace(R)
+    Ftop = jnp.array([R[1, 2] - R[2, 1], R[2, 0] - R[0, 2], R[0, 1] - R[1, 0]])
+    F = jnp.block([
+        [Rtr, Ftop[None, :]],
+        [Ftop[:, None], -Rtr * jnp.eye(3) + R + R.T],
+    ])
+    q = eigh_rightmost(F)
+    q = q * jnp.sign(q[0])
+    a = asinc(q[0])
+    return jnp.stack([2 * q[1] * a, 2 * q[2] * a, 2 * q[3] * a])
+
+
+_rotation_3axis_hess_batched = jit(vmap(
+    jacfwd(jacfwd(_rotation_3axis_masked, argnums=0), argnums=0),
+    in_axes=(0, 0, 0)
+))
+
+
+_rotation_3axis_value_batched = jit(vmap(
+    _rotation_3axis_masked,
+    in_axes=(0, 0, 0)
+))
+
+
+_rotation_3axis_grad_batched = jit(vmap(
+    jacfwd(_rotation_3axis_masked, argnums=0),
+    in_axes=(0, 0, 0)
+))
+
+
+def _rotation_3axis_hvp(pos, refpos, mask, v):
+    """HVP for one fragment, all 3 axes at once.
+
+    Returns shape (3, N, 3) — the directional derivative of the
+    Jacobian (3, N, 3) along v (N, 3).
+    """
+    primals = (pos,)
+    tangents = (v,)
+    _, hvp = jvp(
+        lambda p: jacfwd(_rotation_3axis_masked, argnums=0)(p, refpos, mask),
+        primals, tangents
+    )
+    return hvp
+
+
+_rotation_3axis_hvp_batched_jit = jit(
+    vmap(_rotation_3axis_hvp, in_axes=(0, 0, 0, 0))
+)
+
+
+def _rotation_hess_padded_vmap(positions, refpos_padded, mask):
+    """JIT+vmap'd Hessian for all rotations of one fragment, batched.
+
+    positions: (B, N_max, 3) — fragment positions, padded
+    refpos_padded: (B, N_max, 3) — fragment refpos, centered+padded
+    mask: (B, N_max) — 1 on real atoms, 0 on padding
+
+    Returns: (B, 3, N_max, 3, N_max, 3) — per-fragment, per-axis, full
+    NxN Hessian with padded rows/cols zeroed out.
+    """
+    return _rotation_3axis_hess_batched(positions, refpos_padded, mask)
 
 
 def _rotation_hvp(
@@ -557,25 +708,13 @@ class Rotation(Coordinate):
             return False
         if set(self.indices) != set(other.indices):
             return False
-        if np.any(self.kwargs['refpos'] != other.kwargs['refpos']):
+        if not np.allclose(self.kwargs['refpos'], other.kwargs['refpos']):
             return False
         return True
 
     _eval0 = staticmethod(jit(_rotation))
     _eval1 = staticmethod(jit(jacfwd(_rotation, argnums=0)))
     _eval2 = staticmethod(jit(jacfwd(jacfwd(_rotation, argnums=0), argnums=0)))
-
-    def calc_hessian(self, atoms: Atoms) -> jnp.ndarray:
-        result = np.array(self._eval2(
-            atoms.positions[self.indices], **self.kwargs
-        ))
-        # For linear molecules, the quaternion eigenvalue problem in
-        # _rotation_q has degenerate eigenvalues, producing NaN second
-        # derivatives. The corresponding rotation is physically
-        # meaningless (zero Jacobian), so replacing NaN with 0 is exact.
-        if np.any(np.isnan(result)):
-            np.nan_to_num(result, copy=False)
-        return result
 
 
 def _displacement(
@@ -601,7 +740,7 @@ class Displacement(Coordinate):
     def __eq__(self, other: Coordinate) -> bool:
         if not Coordinate.__eq__(self, other):
             return False
-        return np.all(self.kwargs['refpos'] == other.kwargs['refpos'])
+        return np.allclose(self.kwargs['refpos'], other.kwargs['refpos'])
 
     _eval0 = staticmethod(jit(_displacement))
     _eval1 = staticmethod(jit(_gradient(_displacement)))
@@ -622,6 +761,7 @@ class Bond(Internal):
     _eval0 = staticmethod(jit(_bond))
     _eval1 = staticmethod(_gradient(_bond))
     _eval2 = staticmethod(_hessian(_bond))
+    _eval_cell_grad = staticmethod(_bond_cell_grad_single)
 
     def calc_vec(self, atoms: Atoms) -> np.ndarray:
         tvecs = np.asarray(
@@ -648,6 +788,7 @@ class Angle(Internal):
     _eval0 = staticmethod(jit(_angle))
     _eval1 = staticmethod(_gradient(_angle))
     _eval2 = staticmethod(_hessian(_angle))
+    _eval_cell_grad = staticmethod(_angle_cell_grad_single)
 
 
 def _dihedral(
@@ -667,6 +808,7 @@ class Dihedral(Internal):
     _eval0 = staticmethod(jit(_dihedral))
     _eval1 = staticmethod(_gradient(_dihedral))
     _eval2 = staticmethod(_hessian(_dihedral))
+    _eval_cell_grad = staticmethod(_dihedral_cell_grad_single)
 
 
 Bond.union = Angle
@@ -738,17 +880,24 @@ class BaseInternals:
         self.dummies = dummies
         self.dinds = dinds
 
-        # Cache atom count (atoms are never added/removed during optimization)
+        # Cache atom count (doesn't change during optimization)
         self._natoms = len(atoms)
 
         self.internals = {key: [] for key in self._names}
+        self._internals_set = {key: set() for key in self._names}
         self._active = {key: [] for key in self._names}
         self.cell = None
         self.rcell = None
+        self._rcell_reciprocal_T = None
         self.op = None
+        self._hessian_skeleton = None
 
         # Batched arrays for vectorized computation (built lazily)
         self._batched_arrays_valid = False
+
+        # Lazy caches.
+        self._tvecs_cache = None  # set to {'cell_hash': ..., 'tvecs': ...} on first build
+        self._hvp_buf = None  # reusable buffer for hessian_rdot output
 
     @property
     def natoms(self) -> int:
@@ -757,6 +906,10 @@ class BaseInternals:
     @property
     def ndummies(self) -> int:
         return len(self.dummies)
+
+    @property
+    def ndof(self) -> int:
+        return 3 * (self._natoms + len(self.dummies))
 
     @property
     def ntrans(self) -> int:
@@ -798,15 +951,21 @@ class BaseInternals:
         return len(self._active_indices)
 
     @property
-    def ndof(self) -> int:
-        return 3 * (self._natoms + len(self.dummies))
-
-    @property
     def all_positions(self) -> np.ndarray:
-        """Get combined positions without creating an Atoms object."""
-        if self.ndummies > 0:
-            return np.vstack([self.atoms.positions, self.dummies.positions])
-        return self.atoms.positions
+        """Get combined positions without creating an Atoms object.
+
+        Cached on ``self._cache['all_positions']`` so repeated reads
+        within a single position evaluation reuse the same vstack.
+        ``_cache_check`` clears the cache whenever positions change.
+        """
+        if self.ndummies == 0:
+            return self.atoms.positions
+        cached = self._cache.get('all_positions')
+        if cached is not None:
+            return cached
+        merged = np.vstack([self.atoms.positions, self.dummies.positions])
+        self._cache['all_positions'] = merged
+        return merged
 
     @property
     def all_atoms(self) -> Atoms:
@@ -815,7 +974,7 @@ class BaseInternals:
     @property
     def light_atoms(self) -> LightAtoms:
         """Get lightweight atoms-like object for coordinate calculations."""
-        cell = self.atoms.cell.array if hasattr(self.atoms.cell, 'array') else np.asarray(self.atoms.cell)
+        cell = self.atoms.cell.array
         return LightAtoms(self.all_positions, cell)
 
     def _cache_check(self) -> None:
@@ -823,7 +982,10 @@ class BaseInternals:
         # the last time a property was calculated. These positions are floats,
         # but we use a strict equality check to compare to avoid subtle bugs
         # that might occur during fine-resolution geodesic steps.
-        current_pos = self.all_positions
+        if self.ndummies == 0:
+            current_pos = self.atoms.positions
+        else:
+            current_pos = np.vstack([self.atoms.positions, self.dummies.positions])
         if (
             self._lastpos is None
             or np.any(current_pos != self._lastpos)
@@ -831,6 +993,10 @@ class BaseInternals:
             self._cache = dict()
             self._lastpos = current_pos.copy()
             self._cache_version += 1
+        # Park the freshly-merged positions in the cache so the next
+        # all_positions access doesn't redo the vstack.
+        if self.ndummies > 0:
+            self._cache.setdefault('all_positions', self._lastpos)
 
     def _build_batched_arrays(self) -> None:
         """Build batched index arrays for vectorized computation.
@@ -921,6 +1087,84 @@ class BaseInternals:
             self._dihedral_mask = np.empty(0, dtype=np.float64)
             self._n_dihedrals_actual = 0
 
+        # Precompute flat column indices for direct scatter in hessian_rdot.
+        # For bond (a,b), the non-zero columns in the (ndof,) output are
+        # [3a, 3a+1, 3a+2, 3b, 3b+1, 3b+2].  Analogous for angles (9 cols)
+        # and dihedrals (12 cols).  These are topology-dependent and
+        # invalidated together with the rest of the batched arrays.
+        offsets = np.arange(3)
+        if self._n_bonds_actual > 0:
+            bi = self._bond_indices  # (n_bonds, 2)
+            self._bond_flat_cols = np.concatenate([
+                bi[:, k:k+1] * 3 + offsets for k in range(2)
+            ], axis=1)  # (n_bonds, 6)
+        else:
+            self._bond_flat_cols = np.empty((0, 6), dtype=np.intp)
+
+        if self._n_angles_actual > 0:
+            ai = self._angle_indices  # (n_angles, 3)
+            self._angle_flat_cols = np.concatenate([
+                ai[:, k:k+1] * 3 + offsets for k in range(3)
+            ], axis=1)  # (n_angles, 9)
+        else:
+            self._angle_flat_cols = np.empty((0, 9), dtype=np.intp)
+
+        if self._n_dihedrals_actual > 0:
+            di = self._dihedral_indices  # (n_dihedrals, 4)
+            self._dihedral_flat_cols = np.concatenate([
+                di[:, k:k+1] * 3 + offsets for k in range(4)
+            ], axis=1)  # (n_dihedrals, 12)
+        else:
+            self._dihedral_flat_cols = np.empty((0, 12), dtype=np.intp)
+
+        # Build CSR structure for sparse hessian_rdot output.
+        # Bonds/angles/dihedrals have fixed nnz per row (6/9/12).
+        # Translations have zero rows. Rotations/other are dense (ndof cols).
+        ndof = self.ndof
+        n_trans = len(self.internals['translations'])
+        n_other = len(self.internals['other'])
+        n_rot = len(self.internals['rotations'])
+        n_active = (n_trans + self._n_bonds_actual + self._n_angles_actual
+                    + self._n_dihedrals_actual + n_other + n_rot)
+
+        col_blocks = []
+        nnz_per_row = []
+
+        # Translations: zero rows
+        for _ in range(n_trans):
+            nnz_per_row.append(0)
+
+        # Bonds: 6 nnz per row
+        if self._n_bonds_actual > 0:
+            col_blocks.append(self._bond_flat_cols.ravel())
+            nnz_per_row.extend([6] * self._n_bonds_actual)
+
+        # Angles: 9 nnz per row
+        if self._n_angles_actual > 0:
+            col_blocks.append(self._angle_flat_cols.ravel())
+            nnz_per_row.extend([9] * self._n_angles_actual)
+
+        # Dihedrals: 12 nnz per row
+        if self._n_dihedrals_actual > 0:
+            col_blocks.append(self._dihedral_flat_cols.ravel())
+            nnz_per_row.extend([12] * self._n_dihedrals_actual)
+
+        # Other/rotations: dense rows (ndof cols each)
+        for _ in range(n_other + n_rot):
+            col_blocks.append(np.arange(ndof))
+            nnz_per_row.append(ndof)
+
+        self._csr_indptr = np.zeros(n_active + 1, dtype=np.int32)
+        np.cumsum(nnz_per_row, out=self._csr_indptr[1:])
+        self._csr_indices = np.concatenate(col_blocks).astype(np.int32) if col_blocks else np.empty(0, dtype=np.int32)
+        self._csr_data = np.zeros(len(self._csr_indices), dtype=np.float64)
+        self._csr_n_active = n_active
+        # Precompute data offset for each section
+        self._csr_bond_offset = n_trans * 0  # bonds start after translations (0 nnz)
+        self._csr_angle_offset = self._csr_bond_offset + self._n_bonds_actual * 6
+        self._csr_dih_offset = self._csr_angle_offset + self._n_angles_actual * 9
+        self._csr_other_offset = self._csr_dih_offset + self._n_dihedrals_actual * 12
+
         self._batched_arrays_valid = True
 
     def _get_cached_tvecs(self, cell: np.ndarray) -> Dict[str, np.ndarray]:
@@ -932,7 +1176,7 @@ class BaseInternals:
         Returns both unpadded tvecs (for indexing) and padded tvecs (for batch ops).
         """
         cell_hash = cell.tobytes()
-        if hasattr(self, '_tvecs_cache') and self._tvecs_cache.get('cell_hash') == cell_hash:
+        if self._tvecs_cache is not None and self._tvecs_cache['cell_hash'] == cell_hash:
             return self._tvecs_cache['tvecs']
 
         self._build_batched_arrays()
@@ -977,161 +1221,152 @@ class BaseInternals:
         """Invalidate batched arrays (call when internals change)."""
         self._batched_arrays_valid = False
 
-    # =========================================================================
-    # Helper methods for batched computation
-    # =========================================================================
-
-    def _compute_batched_for_type(
-        self,
-        positions: np.ndarray,
-        indices_padded: np.ndarray,
-        n_actual: int,
-        tvecs_padded: np.ndarray,
-        jax_func,
-        empty_shape: Tuple[int, ...],
-    ):
-        """Compute batched JAX operation for a single coordinate type.
-
-        Args:
-            positions: Full position array
-            indices_padded: Padded indices array for this coord type
-            n_actual: Actual number of coordinates (before padding)
-            tvecs_padded: Padded translation vectors
-            jax_func: JAX function to apply (value, grad, or hess batched)
-            empty_shape: Shape to use for empty result if n_actual == 0
-
-        Returns:
-            Result array sliced to actual size, or empty array
-        """
-        if n_actual == 0:
-            return np.empty(empty_shape)
-        pos_batch = positions[indices_padded]
-        result_padded = np.asarray(device_get(jax_func(pos_batch, tvecs_padded)))
-        return result_padded[:n_actual]
-
     def _compute_batched_values(self, positions: np.ndarray, cell: np.ndarray) -> Dict[str, np.ndarray]:
-        """Compute all internal coordinate values using vectorized operations."""
+        """Compute all internal coordinate values using vectorized operations.
+
+        Uses padded arrays for GPU/SIMD efficiency, then slices to actual size.
+        """
         self._build_batched_arrays()
         tvecs = self._get_cached_tvecs(cell)
+        result = {}
 
-        return {
-            'bonds': self._compute_batched_for_type(
-                positions, self._bond_indices_padded, self._n_bonds_actual,
-                tvecs['bonds_padded'], _bond_value_batched, (0,)),
-            'angles': self._compute_batched_for_type(
-                positions, self._angle_indices_padded, self._n_angles_actual,
-                tvecs['angles_padded'], _angle_value_batched, (0,)),
-            'dihedrals': self._compute_batched_for_type(
-                positions, self._dihedral_indices_padded, self._n_dihedrals_actual,
-                tvecs['dihedrals_padded'], _dihedral_value_batched, (0,)),
-        }
+        # Bonds - use padded arrays for consistent JAX shapes
+        if self._n_bonds_actual > 0:
+            bond_pos = positions[self._bond_indices_padded]  # (n_padded, 2, 3)
+            values_padded = np.asarray(device_get(_bond_value_batched(bond_pos, tvecs['bonds_padded'])))
+            result['bonds'] = values_padded[:self._n_bonds_actual]
+        else:
+            result['bonds'] = np.empty(0)
+
+        # Angles
+        if self._n_angles_actual > 0:
+            angle_pos = positions[self._angle_indices_padded]  # (n_padded, 3, 3)
+            values_padded = np.asarray(device_get(_angle_value_batched(angle_pos, tvecs['angles_padded'])))
+            result['angles'] = values_padded[:self._n_angles_actual]
+        else:
+            result['angles'] = np.empty(0)
+
+        # Dihedrals
+        if self._n_dihedrals_actual > 0:
+            dihedral_pos = positions[self._dihedral_indices_padded]  # (n_padded, 4, 3)
+            values_padded = np.asarray(device_get(_dihedral_value_batched(dihedral_pos, tvecs['dihedrals_padded'])))
+            result['dihedrals'] = values_padded[:self._n_dihedrals_actual]
+        else:
+            result['dihedrals'] = np.empty(0)
+
+        return result
 
     def _compute_batched_gradients(self, positions: np.ndarray, cell: np.ndarray) -> Dict[str, Tuple[np.ndarray, np.ndarray]]:
         """Compute all internal coordinate gradients using vectorized operations.
 
         Returns dict mapping coord type to (indices, gradients) tuples.
+        Uses padded arrays for GPU/SIMD efficiency, then slices to actual size.
         """
         self._build_batched_arrays()
         tvecs = self._get_cached_tvecs(cell)
+        result = {}
 
-        return {
-            'bonds': (
-                self._bond_indices,
-                self._compute_batched_for_type(
-                    positions, self._bond_indices_padded, self._n_bonds_actual,
-                    tvecs['bonds_padded'], _bond_grad_batched, (0, 2, 3))),
-            'angles': (
-                self._angle_indices,
-                self._compute_batched_for_type(
-                    positions, self._angle_indices_padded, self._n_angles_actual,
-                    tvecs['angles_padded'], _angle_grad_batched, (0, 3, 3))),
-            'dihedrals': (
-                self._dihedral_indices,
-                self._compute_batched_for_type(
-                    positions, self._dihedral_indices_padded, self._n_dihedrals_actual,
-                    tvecs['dihedrals_padded'], _dihedral_grad_batched, (0, 4, 3))),
-        }
+        # Bonds - use padded arrays
+        if self._n_bonds_actual > 0:
+            bond_pos = positions[self._bond_indices_padded]  # (n_padded, 2, 3)
+            grads_padded = np.asarray(device_get(_bond_grad_batched(bond_pos, tvecs['bonds_padded'])))
+            result['bonds'] = (self._bond_indices, grads_padded[:self._n_bonds_actual])
+        else:
+            result['bonds'] = (np.empty((0, 2), dtype=np.int32), np.empty((0, 2, 3)))
+
+        # Angles
+        if self._n_angles_actual > 0:
+            angle_pos = positions[self._angle_indices_padded]
+            grads_padded = np.asarray(device_get(_angle_grad_batched(angle_pos, tvecs['angles_padded'])))
+            result['angles'] = (self._angle_indices, grads_padded[:self._n_angles_actual])
+        else:
+            result['angles'] = (np.empty((0, 3), dtype=np.int32), np.empty((0, 3, 3)))
+
+        # Dihedrals
+        if self._n_dihedrals_actual > 0:
+            dihedral_pos = positions[self._dihedral_indices_padded]
+            grads_padded = np.asarray(device_get(_dihedral_grad_batched(dihedral_pos, tvecs['dihedrals_padded'])))
+            result['dihedrals'] = (self._dihedral_indices, grads_padded[:self._n_dihedrals_actual])
+        else:
+            result['dihedrals'] = (np.empty((0, 4), dtype=np.int32), np.empty((0, 4, 3)))
+
+        return result
 
     def _compute_batched_hessians(self, positions: np.ndarray, cell: np.ndarray) -> Dict[str, Tuple[np.ndarray, np.ndarray]]:
         """Compute all internal coordinate hessians using vectorized operations.
 
         Returns dict mapping coord type to (indices, hessians) tuples.
+        Uses padded arrays for GPU/SIMD efficiency, then slices to actual size.
         """
         self._build_batched_arrays()
         tvecs = self._get_cached_tvecs(cell)
+        result = {}
 
-        return {
-            'bonds': (
-                self._bond_indices,
-                self._compute_batched_for_type(
-                    positions, self._bond_indices_padded, self._n_bonds_actual,
-                    tvecs['bonds_padded'], _bond_hess_batched, (0, 2, 3, 2, 3))),
-            'angles': (
-                self._angle_indices,
-                self._compute_batched_for_type(
-                    positions, self._angle_indices_padded, self._n_angles_actual,
-                    tvecs['angles_padded'], _angle_hess_batched, (0, 3, 3, 3, 3))),
-            'dihedrals': (
-                self._dihedral_indices,
-                self._compute_batched_for_type(
-                    positions, self._dihedral_indices_padded, self._n_dihedrals_actual,
-                    tvecs['dihedrals_padded'], _dihedral_hess_batched, (0, 4, 3, 4, 3))),
-        }
+        # Bonds - use padded arrays
+        if self._n_bonds_actual > 0:
+            bond_pos = positions[self._bond_indices_padded]
+            hess_padded = np.asarray(device_get(_bond_hess_batched(bond_pos, tvecs['bonds_padded'])))
+            result['bonds'] = (self._bond_indices, hess_padded[:self._n_bonds_actual])
+        else:
+            result['bonds'] = (np.empty((0, 2), dtype=np.int32), np.empty((0, 2, 3, 2, 3)))
 
-    # =========================================================================
-    # Helper methods for jacobian/hessian assembly
-    # =========================================================================
+        # Angles
+        if self._n_angles_actual > 0:
+            angle_pos = positions[self._angle_indices_padded]
+            hess_padded = np.asarray(device_get(_angle_hess_batched(angle_pos, tvecs['angles_padded'])))
+            result['angles'] = (self._angle_indices, hess_padded[:self._n_angles_actual])
+        else:
+            result['angles'] = (np.empty((0, 3), dtype=np.int32), np.empty((0, 3, 3, 3, 3)))
 
-    @staticmethod
-    def _scatter_jacobian_batch(
-        B: np.ndarray,
-        row: int,
-        indices: np.ndarray,
-        gradients: np.ndarray,
-        active_mask: List[bool],
-    ) -> int:
-        """Scatter batched gradients into Jacobian matrix.
+        # Dihedrals
+        if self._n_dihedrals_actual > 0:
+            dihedral_pos = positions[self._dihedral_indices_padded]
+            hess_padded = np.asarray(device_get(_dihedral_hess_batched(dihedral_pos, tvecs['dihedrals_padded'])))
+            result['dihedrals'] = (self._dihedral_indices, hess_padded[:self._n_dihedrals_actual])
+        else:
+            result['dihedrals'] = (np.empty((0, 4), dtype=np.int32), np.empty((0, 4, 3, 4, 3)))
 
-        Args:
-            B: Jacobian matrix to fill
-            row: Starting row index
-            indices: Coordinate atom indices
-            gradients: Gradient values
-            active_mask: Boolean mask for active coordinates
+        return result
 
-        Returns:
-            New row index after scattering
+    def _compute_batched_cell_gradients(self, positions: np.ndarray, cell: np.ndarray) -> Dict[str, np.ndarray]:
+        """Compute all internal coordinate cell gradients using vectorized operations.
+
+        Returns dict mapping coord type to cell gradient arrays.
+        Each gradient has shape (n_coords, 3, 3) for d(coord)/d(cell).
+        Uses padded arrays for GPU/SIMD efficiency, then slices to actual size.
         """
-        active_arr = np.array(active_mask, dtype=bool)
-        n_active = active_arr.sum()
-        if n_active > 0:
-            rows_idx = np.arange(row, row + n_active)[:, None]
-            B[rows_idx, indices[active_arr]] = gradients[active_arr]
-        return row + n_active
+        self._build_batched_arrays()
+        cell_jax = jnp.asarray(cell, dtype=np.float64)
+        result = {}
 
-    @staticmethod
-    def _append_hessians_batch(
-        hessians: List,
-        n_atoms: int,
-        indices: np.ndarray,
-        hess_values: np.ndarray,
-        active_mask: List[bool],
-    ) -> None:
-        """Append batched hessians to list for active coordinates.
+        # Bonds - use padded arrays for consistent JAX shapes
+        if self._n_bonds_actual > 0:
+            bond_pos = jnp.asarray(positions[self._bond_indices_padded], dtype=np.float64)
+            bond_ncvecs = jnp.asarray(self._bond_ncvecs_padded, dtype=np.float64)
+            grads_padded = np.asarray(device_get(_bond_cell_grad_batched(bond_pos, bond_ncvecs, cell_jax)))
+            result['bonds'] = grads_padded[:self._n_bonds_actual]
+        else:
+            result['bonds'] = np.empty((0, 3, 3))
 
-        Args:
-            hessians: List to append SparseInternalHessian objects to
-            n_atoms: Total number of atoms
-            indices: Coordinate atom indices
-            hess_values: Hessian values
-            active_mask: Boolean mask for active coordinates
-        """
-        active_arr = np.array(active_mask, dtype=bool)
-        if active_arr.any():
-            active_idx = indices[active_arr]
-            active_hess = hess_values[active_arr]
-            for i in range(len(active_idx)):
-                hessians.append(SparseInternalHessian(n_atoms, active_idx[i], active_hess[i].copy()))
+        # Angles
+        if self._n_angles_actual > 0:
+            angle_pos = jnp.asarray(positions[self._angle_indices_padded], dtype=np.float64)
+            angle_ncvecs = jnp.asarray(self._angle_ncvecs_padded, dtype=np.float64)
+            grads_padded = np.asarray(device_get(_angle_cell_grad_batched(angle_pos, angle_ncvecs, cell_jax)))
+            result['angles'] = grads_padded[:self._n_angles_actual]
+        else:
+            result['angles'] = np.empty((0, 3, 3))
+
+        # Dihedrals
+        if self._n_dihedrals_actual > 0:
+            dihedral_pos = jnp.asarray(positions[self._dihedral_indices_padded], dtype=np.float64)
+            dihedral_ncvecs = jnp.asarray(self._dihedral_ncvecs_padded, dtype=np.float64)
+            grads_padded = np.asarray(device_get(_dihedral_cell_grad_batched(dihedral_pos, dihedral_ncvecs, cell_jax)))
+            result['dihedrals'] = grads_padded[:self._n_dihedrals_actual]
+        else:
+            result['dihedrals'] = np.empty((0, 3, 3))
+
+        return result
 
     def copy(self) -> 'BaseInternals':
         raise NotImplementedError
@@ -1141,7 +1376,7 @@ class BaseInternals:
         self._cache_check()
         if 'coords' not in self._cache:
             positions = self.all_positions
-            cell = self.atoms.cell.array if hasattr(self.atoms.cell, 'array') else np.asarray(self.atoms.cell)
+            cell = self.atoms.cell.array
 
             # Use vectorized computation for bonds, angles, dihedrals
             batched_vals = self._compute_batched_values(positions, cell)
@@ -1167,9 +1402,13 @@ class BaseInternals:
             for coord in self.internals['other']:
                 all_coords.append(coord.calc(atoms))
 
-            # Rotations (not batched - usually few)
-            for coord in self.internals['rotations']:
-                all_coords.append(coord.calc(atoms))
+            # Rotations (batched if all 3 axes present per fragment)
+            rot_vals = self._batched_rotation_values(positions)
+            if rot_vals is None:
+                for coord in self.internals['rotations']:
+                    all_coords.append(coord.calc(atoms))
+            else:
+                all_coords.extend(rot_vals)
 
             self._cache['coords'] = np.array(all_coords)
 
@@ -1180,9 +1419,17 @@ class BaseInternals:
     def jacobian(self) -> np.ndarray:
         """Calculates the internal coordinate Jacobian matrix using vectorized operations."""
         self._cache_check()
+
+        # If a fully-built B was cached, return it directly. The cache is
+        # invalidated by _cache_check whenever positions change, and the active
+        # mask is stable within a single position evaluation.
+        cached_B = self._cache.get('jacobian_B')
+        if cached_B is not None:
+            return cached_B
+
         if 'jacobian' not in self._cache:
             positions = self.all_positions
-            cell = self.atoms.cell.array if hasattr(self.atoms.cell, 'array') else np.asarray(self.atoms.cell)
+            cell = self.atoms.cell.array
 
             # Use vectorized computation for bonds, angles, dihedrals
             batched_grads = self._compute_batched_gradients(positions, cell)
@@ -1193,8 +1440,10 @@ class BaseInternals:
                           for coord in self.internals['translations']]
             other_data = [(coord.indices, np.array(coord.calc_gradient(atoms)))
                           for coord in self.internals['other']]
-            rot_data = [(coord.indices, np.array(coord.calc_gradient(atoms)))
-                        for coord in self.internals['rotations']]
+            rot_data = self._batched_rotation_gradients(positions)
+            if rot_data is None:
+                rot_data = [(coord.indices, np.array(coord.calc_gradient(atoms)))
+                            for coord in self.internals['rotations']]
 
             self._cache['jacobian_batched'] = batched_grads
             self._cache['jacobian_nonbatched'] = (trans_data, other_data, rot_data)
@@ -1239,15 +1488,41 @@ class BaseInternals:
                 np.add.at(B, (row, idx), jac)
                 row += 1
 
-        # Batched scatter for bonds, angles, dihedrals
+        # Bonds (batched) - vectorized scatter
         bond_indices, bond_grads = batched['bonds']
-        row = self._scatter_jacobian_batch(B, row, bond_indices, bond_grads, bonds_active)
+        bonds_active_arr = np.array(bonds_active, dtype=bool)
+        n_active_bonds = bonds_active_arr.sum()
+        if n_active_bonds > 0:
+            active_bond_idx = bond_indices[bonds_active_arr]
+            active_bond_grads = bond_grads[bonds_active_arr]
+            # Vectorized scatter: replace loop with advanced indexing
+            rows_idx = np.arange(row, row + n_active_bonds)[:, None]
+            B[rows_idx, active_bond_idx] = active_bond_grads
+            row += n_active_bonds
 
+        # Angles (batched) - vectorized scatter
         angle_indices, angle_grads = batched['angles']
-        row = self._scatter_jacobian_batch(B, row, angle_indices, angle_grads, angles_active)
+        angles_active_arr = np.array(angles_active, dtype=bool)
+        n_active_angles = angles_active_arr.sum()
+        if n_active_angles > 0:
+            active_angle_idx = angle_indices[angles_active_arr]
+            active_angle_grads = angle_grads[angles_active_arr]
+            # Vectorized scatter
+            rows_idx = np.arange(row, row + n_active_angles)[:, None]
+            B[rows_idx, active_angle_idx] = active_angle_grads
+            row += n_active_angles
 
+        # Dihedrals (batched) - vectorized scatter
         dihedral_indices, dihedral_grads = batched['dihedrals']
-        row = self._scatter_jacobian_batch(B, row, dihedral_indices, dihedral_grads, dihedrals_active)
+        dihedrals_active_arr = np.array(dihedrals_active, dtype=bool)
+        n_active_dihedrals = dihedrals_active_arr.sum()
+        if n_active_dihedrals > 0:
+            active_dih_idx = dihedral_indices[dihedrals_active_arr]
+            active_dih_grads = dihedral_grads[dihedrals_active_arr]
+            # Vectorized scatter
+            rows_idx = np.arange(row, row + n_active_dihedrals)[:, None]
+            B[rows_idx, active_dih_idx] = active_dih_grads
+            row += n_active_dihedrals
 
         # Other (not batched)
         for i, (idx, jac) in enumerate(other_data):
@@ -1261,7 +1536,259 @@ class BaseInternals:
                 np.add.at(B, (row, idx), jac)
                 row += 1
 
-        return B.reshape((n_active, 3 * n_atoms))
+        result = B.reshape((n_active, 3 * n_atoms))
+        self._cache['jacobian_B'] = result
+        return result
+
+    def cell_jacobian(self) -> np.ndarray:
+        """Compute Jacobian of internal coordinates with respect to cell matrix.
+
+        Returns:
+            np.ndarray: Shape (n_active_coords, 9) matrix where each row is
+                        the flattened d(coord)/d(cell) gradient.
+
+        Note:
+            - Translations, rotations, and other non-periodic coordinates have
+              zero cell derivatives (they don't depend on the cell).
+            - Only bonds, angles, and dihedrals with non-zero ncvecs have
+              non-zero cell derivatives.
+
+        Raises:
+            ValueError: If the system does not have periodic boundary conditions.
+        """
+        if not np.any(self.atoms.pbc):
+            raise ValueError(
+                "cell_jacobian() requires periodic boundary conditions. "
+                "Set atoms.pbc = True for periodic systems."
+            )
+
+        self._cache_check()
+
+        if 'cell_jacobian' not in self._cache:
+            positions = self.all_positions
+            cell = self.atoms.cell.array
+
+            # Compute batched cell gradients for bonds, angles, dihedrals
+            cell_grads = self._compute_batched_cell_gradients(positions, cell)
+            self._cache['cell_jacobian_batched'] = cell_grads
+            self._cache['cell_jacobian'] = object()
+
+        cell_grads = self._cache['cell_jacobian_batched']
+
+        # Get counts for each type
+        n_trans = len(self.internals['translations'])
+        n_bonds = len(self.internals['bonds'])
+        n_angles = len(self.internals['angles'])
+        n_dihedrals = len(self.internals['dihedrals'])
+        n_other = len(self.internals['other'])
+        n_rot = len(self.internals['rotations'])
+
+        # Build active masks per type
+        active_mask = self._active_mask
+        start = 0
+        trans_active = active_mask[start:start+n_trans]
+        start += n_trans
+        bonds_active = active_mask[start:start+n_bonds]
+        start += n_bonds
+        angles_active = active_mask[start:start+n_angles]
+        start += n_angles
+        dihedrals_active = active_mask[start:start+n_dihedrals]
+        start += n_dihedrals
+        other_active = active_mask[start:start+n_other]
+        start += n_other
+        rot_active = active_mask[start:start+n_rot]
+
+        n_active = sum(active_mask)
+        B_cell = np.zeros((n_active, 3, 3))
+        row = 0
+
+        # Translations have zero cell derivatives (they're CoM positions)
+        row += sum(trans_active)
+
+        # Bonds
+        bonds_active_arr = np.array(bonds_active, dtype=bool)
+        n_active_bonds = bonds_active_arr.sum()
+        if n_active_bonds > 0:
+            B_cell[row:row+n_active_bonds] = cell_grads['bonds'][bonds_active_arr]
+            row += n_active_bonds
+
+        # Angles
+        angles_active_arr = np.array(angles_active, dtype=bool)
+        n_active_angles = angles_active_arr.sum()
+        if n_active_angles > 0:
+            B_cell[row:row+n_active_angles] = cell_grads['angles'][angles_active_arr]
+            row += n_active_angles
+
+        # Dihedrals
+        dihedrals_active_arr = np.array(dihedrals_active, dtype=bool)
+        n_active_dihedrals = dihedrals_active_arr.sum()
+        if n_active_dihedrals > 0:
+            B_cell[row:row+n_active_dihedrals] = cell_grads['dihedrals'][dihedrals_active_arr]
+            row += n_active_dihedrals
+
+        # Other has zero cell derivatives (custom coordinates, not periodic)
+        row += sum(other_active)
+
+        # Rotations have zero cell derivatives
+        row += sum(rot_active)
+
+        # Flatten cell matrix to 9-element vector (row-major order)
+        return B_cell.reshape((n_active, 9))
+
+    def _rotation_padded_inputs(self, positions: np.ndarray):
+        """Build padded (pos, refpos, mask) batches grouped by fragment.
+
+        Returns ``(pos_pad, ref_pad, mask, frag_indices, frag_axis_slots,
+        valid)`` where:
+          pos_pad/ref_pad shape (n_frags, N_max, 3),
+          mask shape (n_frags, N_max),
+          frag_indices: list of np.array per fragment,
+          frag_axis_slots: list of [axis0_idx, axis1_idx, axis2_idx]
+            per fragment (each entry is the original Rotation index),
+          valid: True if all fragments have all 3 axes.
+        Cached per geometry on ``self._cache``.
+        """
+        cached = self._cache.get('rotation_pad')
+        if cached is not None:
+            return cached
+        rotations = self.internals['rotations']
+        if not rotations:
+            out = (None, None, None, [], [], True)
+            self._cache['rotation_pad'] = out
+            return out
+        groups = {}
+        for i, r in enumerate(rotations):
+            key = (tuple(r.indices), r.kwargs['refpos'].tobytes())
+            slot = groups.setdefault(key, [None, None, None])
+            slot[r.kwargs['axis']] = i
+        if any(None in slot for slot in groups.values()):
+            out = (None, None, None, [], [], False)
+            self._cache['rotation_pad'] = out
+            return out
+        n_frags = len(groups)
+        n_max = max(len(r.indices) for r in rotations)
+        pos_pad = np.zeros((n_frags, n_max, 3), dtype=np.float64)
+        ref_pad = np.zeros((n_frags, n_max, 3), dtype=np.float64)
+        mask = np.zeros((n_frags, n_max), dtype=np.float64)
+        frag_indices = []
+        frag_axis_slots = []
+        for fi, slot in enumerate(groups.values()):
+            r0 = rotations[slot[0]]
+            n = len(r0.indices)
+            pos_pad[fi, :n] = positions[r0.indices]
+            ref_pad[fi, :n] = r0.kwargs['refpos']
+            mask[fi, :n] = 1.0
+            frag_indices.append(np.asarray(r0.indices))
+            frag_axis_slots.append(slot)
+        out = (pos_pad, ref_pad, mask, frag_indices, frag_axis_slots, True)
+        self._cache['rotation_pad'] = out
+        return out
+
+    def _batched_rotation_values(self, positions: np.ndarray):
+        """Per-Rotation values via one padded+vmapped JAX dispatch.
+
+        Returns a length-N_rotations list of floats in original order,
+        or None when the heterogeneous fall-back is required.
+        """
+        rotations = self.internals['rotations']
+        if not rotations:
+            return []
+        pos_pad, ref_pad, mask, _, slots, valid = self._rotation_padded_inputs(positions)
+        if not valid:
+            return None
+        vals_padded = np.asarray(device_get(_rotation_3axis_value_batched(
+            jnp.asarray(pos_pad), jnp.asarray(ref_pad), jnp.asarray(mask)
+        )))
+        # vals_padded.shape == (n_frags, 3)
+        out = [None] * len(rotations)
+        for fi, slot in enumerate(slots):
+            for axis, rot_idx in enumerate(slot):
+                out[rot_idx] = float(vals_padded[fi, axis])
+        return out
+
+    def _batched_rotation_gradients(self, positions: np.ndarray):
+        """Per-Rotation gradients via one padded+vmapped JAX dispatch.
+
+        Returns a list of ``(indices, grad)`` tuples in original order,
+        or None when the heterogeneous fall-back is required.
+        """
+        rotations = self.internals['rotations']
+        if not rotations:
+            return []
+        pos_pad, ref_pad, mask, frag_indices, slots, valid = (
+            self._rotation_padded_inputs(positions)
+        )
+        if not valid:
+            return None
+        grads_padded = np.asarray(device_get(_rotation_3axis_grad_batched(
+            jnp.asarray(pos_pad), jnp.asarray(ref_pad), jnp.asarray(mask)
+        )))
+        # grads_padded.shape == (n_frags, 3, N_max, 3)
+        out = [None] * len(rotations)
+        for fi, slot in enumerate(slots):
+            n = len(frag_indices[fi])
+            for axis, rot_idx in enumerate(slot):
+                out[rot_idx] = (frag_indices[fi], grads_padded[fi, axis, :n, :])
+        return out
+
+    def _batched_rotation_hessians(self, positions: np.ndarray):
+        """Compute per-Rotation Hessians via one padded+vmapped JAX dispatch.
+
+        Each fragment owns 3 Rotation objects (axes 0,1,2) that share
+        the same atom indices and refpos. We group them by fragment,
+        pad to the max-fragment-size across the system, run one
+        vmapped call to ``_rotation_hess_padded_vmap``, and slice the
+        result back into per-Rotation arrays.
+
+        On AJEYAQ (4 fragments x 3 axes = 12 Rotations) this drops the
+        rotation portion of int.hessian build from ~14ms to ~1ms.
+        Returns a list of ``(indices, hess)`` tuples in the original
+        per-Rotation order, matching the shape Internals.hessian
+        expects.
+        """
+        rotations = self.internals['rotations']
+        if not rotations:
+            return []
+        pos_pad, ref_pad, mask, frag_indices, slots, valid = (
+            self._rotation_padded_inputs(positions)
+        )
+        if not valid:
+            atoms = self.light_atoms
+            return [(r.indices, np.array(r.calc_hessian(atoms)))
+                    for r in rotations]
+        hess_padded = np.asarray(device_get(_rotation_hess_padded_vmap(
+            jnp.asarray(pos_pad), jnp.asarray(ref_pad), jnp.asarray(mask)
+        )))
+        # hess_padded.shape == (n_frags, 3, N_max, 3, N_max, 3)
+        out = [None] * len(rotations)
+        for fi, slot in enumerate(slots):
+            n = len(frag_indices[fi])
+            for axis, rot_idx in enumerate(slot):
+                h = hess_padded[fi, axis, :n, :, :n, :]
+                out[rot_idx] = (frag_indices[fi], h)
+        return out
+
+    def _get_hessian_skeleton(self, hessians):
+        """Return a cached SparseInternalHessiansSkeleton for ``hessians``.
+
+        The skeleton holds index-derived data (per-size groupings, scatter
+        indices) that depend only on which coordinates exist and which
+        atom indices they touch — not on positions or Hessian values. We
+        invalidate by total coord count + active mask, which jointly
+        cover the mutation paths: ``add_dummy_to_internals`` /
+        ``find_all_*`` / ``check_for_bad_internals`` regenerations grow
+        ``self.internals``, while ``apply_inequalities`` /
+        ``validate_inequalities`` flip ``self._active``.
+        """
+        key = (len(hessians), self.natoms + self.ndummies,
+               tuple(self._active_mask))
+        cached = self._hessian_skeleton
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        skeleton = SparseInternalHessiansSkeleton(hessians,
+                                                  self.natoms + self.ndummies)
+        self._hessian_skeleton = (key, skeleton)
+        return skeleton
 
     def hessian(self) -> np.ndarray:
         """Calculates the Hessian matrix for each internal coordinate using vectorized operations."""
@@ -1273,19 +1800,28 @@ class BaseInternals:
 
         if 'hessian' not in self._cache:
             positions = self.all_positions
-            cell = self.atoms.cell.array if hasattr(self.atoms.cell, 'array') else np.asarray(self.atoms.cell)
+            cell = self.atoms.cell.array
 
             # Use vectorized computation for bonds, angles, dihedrals
             batched_hess = self._compute_batched_hessians(positions, cell)
 
-            # Non-batched coords use lightweight atoms
+            # Non-batched coords use lightweight atoms. Translation hessians are
+            # identically zero (translations are linear in positions), so cache
+            # one zero array per (n,) and reuse — avoids 24+ JAX calls per
+            # hessian rebuild on systems with TRICs.
             atoms = self.light_atoms
-            trans_data = [(coord.indices, np.array(coord.calc_hessian(atoms)))
-                          for coord in self.internals['translations']]
+            trans_data = []
+            zero_cache = {}
+            for coord in self.internals['translations']:
+                n = len(coord.indices)
+                z = zero_cache.get(n)
+                if z is None:
+                    z = np.zeros((n, 3, n, 3))
+                    zero_cache[n] = z
+                trans_data.append((coord.indices, z))
             other_data = [(coord.indices, np.array(coord.calc_hessian(atoms)))
                           for coord in self.internals['other']]
-            rot_data = [(coord.indices, np.array(coord.calc_hessian(atoms)))
-                        for coord in self.internals['rotations']]
+            rot_data = self._batched_rotation_hessians(positions)
 
             self._cache['hessian_batched'] = batched_hess
             self._cache['hessian_nonbatched'] = (trans_data, other_data, rot_data)
@@ -1322,36 +1858,57 @@ class BaseInternals:
         n_atoms = self.natoms + self.ndummies
         hessians = []
 
-        # Translations (not batched)
+        # Translations (not batched). Hessian rows are stored in cached
+        # nonbatched data; SparseInternalHessian only reads .vals so views are
+        # safe.
         for i, (idx, hess) in enumerate(trans_data):
             if trans_active[i]:
-                hessians.append(SparseInternalHessian(n_atoms, np.array(idx), hess.copy()))
+                hessians.append(SparseInternalHessian(n_atoms, idx, hess))
 
-        # Batched hessian append for bonds, angles, dihedrals
+        # Bonds (batched). Fancy indexing already returns a fresh array; per-row
+        # views into it are read-only consumers, so no per-coord copy is needed.
         bond_indices, bond_hess = batched['bonds']
-        self._append_hessians_batch(hessians, n_atoms, bond_indices, bond_hess, bonds_active)
+        bonds_active_arr = np.asarray(bonds_active, dtype=bool)
+        if bonds_active_arr.any():
+            active_bond_idx = bond_indices[bonds_active_arr]
+            active_bond_hess = bond_hess[bonds_active_arr]
+            for i in range(len(active_bond_idx)):
+                hessians.append(SparseInternalHessian(n_atoms, active_bond_idx[i], active_bond_hess[i]))
 
+        # Angles (batched)
         angle_indices, angle_hess = batched['angles']
-        self._append_hessians_batch(hessians, n_atoms, angle_indices, angle_hess, angles_active)
+        angles_active_arr = np.asarray(angles_active, dtype=bool)
+        if angles_active_arr.any():
+            active_angle_idx = angle_indices[angles_active_arr]
+            active_angle_hess = angle_hess[angles_active_arr]
+            for i in range(len(active_angle_idx)):
+                hessians.append(SparseInternalHessian(n_atoms, active_angle_idx[i], active_angle_hess[i]))
 
+        # Dihedrals (batched)
         dihedral_indices, dihedral_hess = batched['dihedrals']
-        self._append_hessians_batch(hessians, n_atoms, dihedral_indices, dihedral_hess, dihedrals_active)
+        dihedrals_active_arr = np.asarray(dihedrals_active, dtype=bool)
+        if dihedrals_active_arr.any():
+            active_dih_idx = dihedral_indices[dihedrals_active_arr]
+            active_dih_hess = dihedral_hess[dihedrals_active_arr]
+            for i in range(len(active_dih_idx)):
+                hessians.append(SparseInternalHessian(n_atoms, active_dih_idx[i], active_dih_hess[i]))
 
         # Other (not batched)
         for i, (idx, hess) in enumerate(other_data):
             if other_active[i]:
-                hessians.append(SparseInternalHessian(n_atoms, np.array(idx), hess.copy()))
+                hessians.append(SparseInternalHessian(n_atoms, idx, hess))
 
         # Rotations (not batched)
         for i, (idx, hess) in enumerate(rot_data):
             if rot_active[i]:
-                hessians.append(SparseInternalHessian(n_atoms, np.array(idx), hess.copy()))
+                hessians.append(SparseInternalHessian(n_atoms, idx, hess))
 
-        result = SparseInternalHessians(hessians, self.ndof)
+        result = SparseInternalHessians(hessians, self.ndof,
+                                        skeleton=self._get_hessian_skeleton(hessians))
         self._cache['hessian_result'] = result
         return result
 
-    def hessian_rdot(self, v: np.ndarray) -> np.ndarray:
+    def hessian_rdot(self, v: np.ndarray):
         """Compute Hessian @ v for all internal coordinates using direct HVP.
 
         This computes the same result as hessian().rdot(v) but uses forward-over-reverse
@@ -1362,11 +1919,13 @@ class BaseInternals:
             v: Vector of shape (ndof,) to multiply with each coordinate's Hessian
 
         Returns:
-            Array of shape (n_active_coords, ndof) where each row is H_i @ v
+            Sparse CSR matrix of shape (n_active_coords, ndof) where each row
+            is H_i @ v. Returns dense ndarray as fallback when not all
+            coordinates are active.
         """
         self._cache_check()
         positions = self.all_positions
-        cell = self.atoms.cell.array if hasattr(self.atoms.cell, 'array') else np.asarray(self.atoms.cell)
+        cell = self.atoms.cell.array
         self._build_batched_arrays()
         tvecs = self._get_cached_tvecs(cell)
 
@@ -1397,22 +1956,294 @@ class BaseInternals:
         start += n_other
         rot_active = active_mask[start:start+n_rot]
 
-        results = []
+        n_active = sum(active_mask)
 
-        # Translations - Hessian is zero (translation is linear: mean of positions)
-        # So HVP is always zero, just append zero rows
+        # Fast path: when all coords are active, use pre-built CSR structure
+        use_sparse = (n_active == self._csr_n_active)
+
+        if use_sparse:
+            data = self._csr_data
+            data[:] = 0
+        else:
+            if (self._hvp_buf is None
+                    or self._hvp_buf.shape != (n_active, ndof)):
+                self._hvp_buf = np.zeros((n_active, ndof))
+            out = self._hvp_buf
+            out[:] = 0
+
+        row = 0  # Current write position in output
+
+        # Translations - Hessian is zero
         n_active_trans = sum(trans_active)
-        if n_active_trans > 0:
-            results.append(np.zeros((n_active_trans, ndof)))
+        # out[row:row+n_active_trans] is already zero from the clear
+        row += n_active_trans
 
-        # Bonds - use batched HVP with vectorized scatter
+        # Launch all JAX HVP computations, deferring device_get
+        # This allows JAX to pipeline the computations before we block on transfer
+
+        bond_jax_result = None
+        bond_active_idx = None
         if bonds_active.any() and self._n_bonds_actual > 0:
             if bonds_active.all():
-                # All bonds active - use padded arrays to avoid recompilation
                 bond_pos = positions[self._bond_indices_padded]
                 bond_tvecs = tvecs['bonds_padded']
                 v_sub = v_atoms[self._bond_indices_padded]
-                hvp_padded = np.asarray(device_get(_bond_hvp_batched(bond_pos, bond_tvecs, v_sub)))
+                bond_jax_result = _bond_hvp_batched(bond_pos, bond_tvecs, v_sub)
+                bond_active_idx = self._bond_indices
+            else:
+                bond_active_idx = self._bond_indices[bonds_active]
+                bond_pos = positions[bond_active_idx]
+                bond_tvecs = tvecs['bonds'][bonds_active]
+                v_sub = v_atoms[bond_active_idx]
+                bond_jax_result = _bond_hvp_batched(bond_pos, bond_tvecs, v_sub)
+
+        angle_jax_result = None
+        angle_active_idx = None
+        if angles_active.any() and self._n_angles_actual > 0:
+            if angles_active.all():
+                angle_pos = positions[self._angle_indices_padded]
+                angle_tvecs = tvecs['angles_padded']
+                v_sub = v_atoms[self._angle_indices_padded]
+                angle_jax_result = _angle_hvp_batched(angle_pos, angle_tvecs, v_sub)
+                angle_active_idx = self._angle_indices
+            else:
+                angle_active_idx = self._angle_indices[angles_active]
+                angle_pos = positions[angle_active_idx]
+                angle_tvecs = tvecs['angles'][angles_active]
+                v_sub = v_atoms[angle_active_idx]
+                angle_jax_result = _angle_hvp_batched(angle_pos, angle_tvecs, v_sub)
+
+        dih_jax_result = None
+        dih_active_idx = None
+        if dihedrals_active.any() and self._n_dihedrals_actual > 0:
+            if dihedrals_active.all():
+                dih_pos = positions[self._dihedral_indices_padded]
+                dih_tvecs = tvecs['dihedrals_padded']
+                v_sub = v_atoms[self._dihedral_indices_padded]
+                dih_jax_result = _dihedral_hvp_batched(dih_pos, dih_tvecs, v_sub)
+                dih_active_idx = self._dihedral_indices
+            else:
+                dih_active_idx = self._dihedral_indices[dihedrals_active]
+                dih_pos = positions[dih_active_idx]
+                dih_tvecs = tvecs['dihedrals'][dihedrals_active]
+                v_sub = v_atoms[dih_active_idx]
+                dih_jax_result = _dihedral_hvp_batched(dih_pos, dih_tvecs, v_sub)
+
+        # Launch rotation HVPs: one vmapped dispatch per fragment x 3 axes
+        # when all rotations are active and all fragments have all 3 axes.
+        # Otherwise fall back to per-rotation calls.
+        rot_jax_results = []
+        rot_indices = []
+        rot_batched_result = None
+        rot_batched_slots = None
+        rot_batched_frag_indices = None
+        all_rot_active = bool(np.asarray(rot_active, dtype=bool).all())
+        if all_rot_active and self.internals['rotations']:
+            pos_pad, ref_pad, mask, frag_indices, slots, valid = (
+                self._rotation_padded_inputs(positions)
+            )
+        else:
+            valid = False
+        if valid:
+            n_max = mask.shape[1]
+            v_pad = np.zeros((len(frag_indices), n_max, 3), dtype=np.float64)
+            for fi, fi_idx in enumerate(frag_indices):
+                v_pad[fi, :len(fi_idx)] = v_atoms[fi_idx]
+            rot_batched_result = _rotation_3axis_hvp_batched_jit(
+                jnp.asarray(pos_pad), jnp.asarray(ref_pad),
+                jnp.asarray(mask), jnp.asarray(v_pad),
+            )
+            rot_batched_slots = slots
+            rot_batched_frag_indices = frag_indices
+        else:
+            for i, coord in enumerate(self.internals['rotations']):
+                if rot_active[i]:
+                    idx = np.array(coord.indices)
+                    pos = positions[idx]
+                    v_sub = v_atoms[idx]
+                    axis = coord.kwargs['axis']
+                    refpos = coord.kwargs['refpos']
+                    rot_jax_results.append(
+                        (_rotation_hvp_jit(pos, axis, refpos, v_sub), idx)
+                    )
+
+        # Now collect results with device_get and scatter into output
+
+        if bond_jax_result is not None:
+            hvp = np.asarray(device_get(bond_jax_result))
+            if bonds_active.all():
+                hvp = hvp[:self._n_bonds_actual]
+            n_coords = self._n_bonds_actual if bonds_active.all() else int(bonds_active.sum())
+            if use_sparse:
+                off = self._csr_bond_offset
+                data[off:off + n_coords * 6] = hvp.reshape(-1)
+            else:
+                flat_cols = self._bond_flat_cols if bonds_active.all() else self._bond_flat_cols[bonds_active]
+                out[row:row+n_coords, :] = 0
+                out[np.arange(row, row+n_coords)[:, None], flat_cols] = hvp.reshape(n_coords, -1)
+            row += n_coords
+
+        if angle_jax_result is not None:
+            hvp = np.asarray(device_get(angle_jax_result))
+            if angles_active.all():
+                hvp = hvp[:self._n_angles_actual]
+            n_coords = self._n_angles_actual if angles_active.all() else int(angles_active.sum())
+            if use_sparse:
+                off = self._csr_angle_offset
+                data[off:off + n_coords * 9] = hvp.reshape(-1)
+            else:
+                flat_cols = self._angle_flat_cols if angles_active.all() else self._angle_flat_cols[angles_active]
+                out[row:row+n_coords, :] = 0
+                out[np.arange(row, row+n_coords)[:, None], flat_cols] = hvp.reshape(n_coords, -1)
+            row += n_coords
+
+        if dih_jax_result is not None:
+            hvp = np.asarray(device_get(dih_jax_result))
+            if dihedrals_active.all():
+                hvp = hvp[:self._n_dihedrals_actual]
+            n_coords = self._n_dihedrals_actual if dihedrals_active.all() else int(dihedrals_active.sum())
+            if use_sparse:
+                off = self._csr_dih_offset
+                data[off:off + n_coords * 12] = hvp.reshape(-1)
+            else:
+                flat_cols = self._dihedral_flat_cols if dihedrals_active.all() else self._dihedral_flat_cols[dihedrals_active]
+                out[row:row+n_coords, :] = 0
+                out[np.arange(row, row+n_coords)[:, None], flat_cols] = hvp.reshape(n_coords, -1)
+            row += n_coords
+
+        # Other - use existing hessian computation (typically few coords, loop is fine)
+        atoms = self.light_atoms
+        off = self._csr_other_offset if use_sparse else 0
+        for i, coord in enumerate(self.internals['other']):
+            if other_active[i]:
+                hess = np.array(coord.calc_hessian(atoms))
+                idx = np.array(coord.indices)
+                v_sub = v_atoms[idx]
+                hvp = np.einsum('aibj,bj->ai', hess, v_sub)
+                if use_sparse:
+                    dense_row = np.zeros(ndof)
+                    dense_row.reshape((-1, 3))[idx] = hvp
+                    data[off:off + ndof] = dense_row
+                    off += ndof
+                else:
+                    out_row = out[row].reshape((-1, 3))
+                    out_row[idx] = hvp
+                row += 1
+
+        # Rotations - collect results (batched or per-rotation)
+        if rot_batched_result is not None:
+            hvp_padded = np.asarray(device_get(rot_batched_result))
+            # hvp_padded.shape == (n_frags, 3, N_max, 3)
+            # Reassemble in original Rotation order
+            ordered = [None] * len(self.internals['rotations'])
+            for fi, slot in enumerate(rot_batched_slots):
+                n = len(rot_batched_frag_indices[fi])
+                for axis, rot_idx in enumerate(slot):
+                    ordered[rot_idx] = (
+                        hvp_padded[fi, axis, :n, :],
+                        rot_batched_frag_indices[fi],
+                    )
+            for i, coord in enumerate(self.internals['rotations']):
+                if not rot_active[i]:
+                    continue
+                hvp, idx = ordered[i]
+                if use_sparse:
+                    dense_row = np.zeros(ndof)
+                    dense_row.reshape((-1, 3))[idx] = hvp
+                    data[off:off + ndof] = dense_row
+                    off += ndof
+                else:
+                    out_row = out[row].reshape((-1, 3))
+                    out_row[idx] = hvp
+                row += 1
+        else:
+            for jax_result, idx in rot_jax_results:
+                hvp = np.asarray(device_get(jax_result))
+                if use_sparse:
+                    dense_row = np.zeros(ndof)
+                    dense_row.reshape((-1, 3))[idx] = hvp
+                    data[off:off + ndof] = dense_row
+                    off += ndof
+                else:
+                    out_row = out[row].reshape((-1, 3))
+                    out_row[idx] = hvp
+                row += 1
+
+        if use_sparse:
+            return sparse.csr_matrix(
+                (data, self._csr_indices, self._csr_indptr),
+                shape=(self._csr_n_active, ndof), copy=False,
+            )
+        return out[:row]
+
+    def hessian_rdot_vecs(self, v: np.ndarray, *us: np.ndarray):
+        """Compute (H_i @ v) · u for all active internal coordinates.
+
+        Equivalent to ``[hessian_rdot(v) @ u for u in us]`` but avoids
+        materializing the dense (n_coords, ndof) matrix.  Each element *i*
+        of a result vector is the dot product of coordinate *i*'s
+        Hessian-vector product row with *u*.
+
+        Args:
+            v: Vector of shape (ndof,) — the HVP direction.
+            *us: One or more vectors of shape (ndof,) to contract with.
+
+        Returns:
+            Tuple of arrays, each of shape (n_active_coords,).
+        """
+        self._cache_check()
+        positions = self.all_positions
+        cell = self.atoms.cell.array
+        self._build_batched_arrays()
+        tvecs = self._get_cached_tvecs(cell)
+
+        v_atoms = v.reshape((-1, 3))
+        u_atoms_list = [u.reshape((-1, 3)) for u in us]
+        n_us = len(us)
+
+        # Active mask bookkeeping (same as hessian_rdot)
+        active_mask = self._active_mask
+        n_trans = len(self.internals['translations'])
+        n_bonds = len(self.internals['bonds'])
+        n_angles = len(self.internals['angles'])
+        n_dihedrals = len(self.internals['dihedrals'])
+        n_other = len(self.internals['other'])
+        n_rot = len(self.internals['rotations'])
+
+        start = 0
+        trans_active = active_mask[start:start + n_trans]
+        start += n_trans
+        bonds_active = np.array(active_mask[start:start + n_bonds], dtype=bool)
+        start += n_bonds
+        angles_active = np.array(active_mask[start:start + n_angles], dtype=bool)
+        start += n_angles
+        dihedrals_active = np.array(
+            active_mask[start:start + n_dihedrals], dtype=bool
+        )
+        start += n_dihedrals
+        other_active = active_mask[start:start + n_other]
+        start += n_other
+        rot_active = active_mask[start:start + n_rot]
+
+        # Collect per-coordinate-type result fragments for each u
+        results = [[] for _ in range(n_us)]
+
+        # --- Translations: Hessian is zero → dot product is zero ---
+        n_active_trans = sum(trans_active)
+        if n_active_trans > 0:
+            z = np.zeros(n_active_trans)
+            for r in results:
+                r.append(z)
+
+        # --- Bonds ---
+        if bonds_active.any() and self._n_bonds_actual > 0:
+            if bonds_active.all():
+                bond_pos = positions[self._bond_indices_padded]
+                bond_tvecs = tvecs['bonds_padded']
+                v_sub = v_atoms[self._bond_indices_padded]
+                hvp_padded = np.asarray(
+                    device_get(_bond_hvp_batched(bond_pos, bond_tvecs, v_sub))
+                )
                 hvp = hvp_padded[:self._n_bonds_actual]
                 active_idx = self._bond_indices
             else:
@@ -1420,21 +2251,26 @@ class BaseInternals:
                 bond_pos = positions[active_idx]
                 bond_tvecs = tvecs['bonds'][bonds_active]
                 v_sub = v_atoms[active_idx]
-                hvp = np.asarray(device_get(_bond_hvp_batched(bond_pos, bond_tvecs, v_sub)))
-            # Vectorized scatter: replace loop with advanced indexing
-            n_coords = len(active_idx)
-            result = np.zeros((n_coords, n_atoms, 3))
-            row_idx = np.arange(n_coords)[:, None]
-            result[row_idx, active_idx] = hvp
-            results.append(result.reshape((n_coords, ndof)))
+                hvp = np.asarray(
+                    device_get(_bond_hvp_batched(bond_pos, bond_tvecs, v_sub))
+                )
+            for k, u_atoms in enumerate(u_atoms_list):
+                u_gathered = u_atoms[active_idx]  # (n_bonds, 2, 3)
+                results[k].append(
+                    np.sum(hvp * u_gathered, axis=(1, 2))
+                )
 
-        # Angles - use batched HVP with vectorized scatter
+        # --- Angles ---
         if angles_active.any() and self._n_angles_actual > 0:
             if angles_active.all():
                 angle_pos = positions[self._angle_indices_padded]
                 angle_tvecs = tvecs['angles_padded']
                 v_sub = v_atoms[self._angle_indices_padded]
-                hvp_padded = np.asarray(device_get(_angle_hvp_batched(angle_pos, angle_tvecs, v_sub)))
+                hvp_padded = np.asarray(
+                    device_get(
+                        _angle_hvp_batched(angle_pos, angle_tvecs, v_sub)
+                    )
+                )
                 hvp = hvp_padded[:self._n_angles_actual]
                 active_idx = self._angle_indices
             else:
@@ -1442,21 +2278,30 @@ class BaseInternals:
                 angle_pos = positions[active_idx]
                 angle_tvecs = tvecs['angles'][angles_active]
                 v_sub = v_atoms[active_idx]
-                hvp = np.asarray(device_get(_angle_hvp_batched(angle_pos, angle_tvecs, v_sub)))
-            # Vectorized scatter
-            n_coords = len(active_idx)
-            result = np.zeros((n_coords, n_atoms, 3))
-            row_idx = np.arange(n_coords)[:, None]
-            result[row_idx, active_idx] = hvp
-            results.append(result.reshape((n_coords, ndof)))
+                hvp = np.asarray(
+                    device_get(
+                        _angle_hvp_batched(angle_pos, angle_tvecs, v_sub)
+                    )
+                )
+            for k, u_atoms in enumerate(u_atoms_list):
+                u_gathered = u_atoms[active_idx]  # (n_angles, 3, 3)
+                results[k].append(
+                    np.sum(hvp * u_gathered, axis=(1, 2))
+                )
 
-        # Dihedrals - use batched HVP with vectorized scatter
+        # --- Dihedrals ---
         if dihedrals_active.any() and self._n_dihedrals_actual > 0:
             if dihedrals_active.all():
                 dih_pos = positions[self._dihedral_indices_padded]
                 dih_tvecs = tvecs['dihedrals_padded']
                 v_sub = v_atoms[self._dihedral_indices_padded]
-                hvp_padded = np.asarray(device_get(_dihedral_hvp_batched(dih_pos, dih_tvecs, v_sub)))
+                hvp_padded = np.asarray(
+                    device_get(
+                        _dihedral_hvp_batched(
+                            dih_pos, dih_tvecs, v_sub
+                        )
+                    )
+                )
                 hvp = hvp_padded[:self._n_dihedrals_actual]
                 active_idx = self._dihedral_indices
             else:
@@ -1464,15 +2309,20 @@ class BaseInternals:
                 dih_pos = positions[active_idx]
                 dih_tvecs = tvecs['dihedrals'][dihedrals_active]
                 v_sub = v_atoms[active_idx]
-                hvp = np.asarray(device_get(_dihedral_hvp_batched(dih_pos, dih_tvecs, v_sub)))
-            # Vectorized scatter
-            n_coords = len(active_idx)
-            result = np.zeros((n_coords, n_atoms, 3))
-            row_idx = np.arange(n_coords)[:, None]
-            result[row_idx, active_idx] = hvp
-            results.append(result.reshape((n_coords, ndof)))
+                hvp = np.asarray(
+                    device_get(
+                        _dihedral_hvp_batched(
+                            dih_pos, dih_tvecs, v_sub
+                        )
+                    )
+                )
+            for k, u_atoms in enumerate(u_atoms_list):
+                u_gathered = u_atoms[active_idx]  # (n_dihedrals, 4, 3)
+                results[k].append(
+                    np.sum(hvp * u_gathered, axis=(1, 2))
+                )
 
-        # Other - use existing hessian computation (typically few coords, loop is fine)
+        # --- Other (typically few coords, loop is fine) ---
         atoms = self.light_atoms
         for i, coord in enumerate(self.internals['other']):
             if other_active[i]:
@@ -1480,11 +2330,13 @@ class BaseInternals:
                 idx = np.array(coord.indices)
                 v_sub = v_atoms[idx]
                 hvp = np.einsum('aibj,bj->ai', hess, v_sub)
-                row = np.zeros(ndof)
-                row.reshape((-1, 3))[idx] = hvp
-                results.append(row[None, :])  # Shape (1, ndof) for consistency
+                for k, u_atoms in enumerate(u_atoms_list):
+                    u_sub = u_atoms[idx]
+                    results[k].append(
+                        np.array([np.sum(hvp * u_sub)])
+                    )
 
-        # Rotations - use O(N) HVP (typically few coords, loop is fine)
+        # --- Rotations ---
         for i, coord in enumerate(self.internals['rotations']):
             if rot_active[i]:
                 idx = np.array(coord.indices)
@@ -1492,14 +2344,25 @@ class BaseInternals:
                 v_sub = v_atoms[idx]
                 axis = coord.kwargs['axis']
                 refpos = coord.kwargs['refpos']
-                hvp = np.asarray(device_get(_rotation_hvp_jit(pos, axis, refpos, v_sub)))
-                row = np.zeros(ndof)
-                row.reshape((-1, 3))[idx] = hvp
-                results.append(row[None, :])  # Shape (1, ndof) for consistency
+                hvp = np.asarray(
+                    device_get(
+                        _rotation_hvp_jit(pos, axis, refpos, v_sub)
+                    )
+                )
+                for k, u_atoms in enumerate(u_atoms_list):
+                    u_sub = u_atoms[idx]
+                    results[k].append(
+                        np.array([np.sum(hvp * u_sub)])
+                    )
 
-        if results:
-            return np.vstack(results)
-        return np.empty((0, ndof))
+        # Concatenate fragments for each u
+        out = []
+        for r in results:
+            if r:
+                out.append(np.concatenate(r))
+            else:
+                out.append(np.empty(0))
+        return tuple(out)
 
     def wrap(self, vec: np.ndarray) -> np.ndarray:
         """Wraps an internal coord. displacement vector into a valid domain."""
@@ -1521,13 +2384,14 @@ class BaseInternals:
 
     def _get_neighbors(self, dx: np.ndarray) -> Iterator[np.ndarray]:
         pbc = self.atoms.pbc
-        if self.cell is None or not np.all(self.cell == self.atoms.cell):
+        if self.cell is None or not np.allclose(self.cell, self.atoms.cell):
             self.cell = self.atoms.cell.array.copy()
             rcell, self.op = minkowski_reduce(
                 complete_cell(self.cell), pbc=pbc
             )
             self.rcell = Cell(rcell)
-        dx_sc = dx @ self.rcell.reciprocal().T
+            self._rcell_reciprocal_T = self.rcell.reciprocal().T
+        dx_sc = dx @ self._rcell_reciprocal_T
         offset = np.zeros(3, dtype=np.int32)
         for _ in range(2):
             offset += pbc * ((dx_sc - offset) // 1.).astype(np.int32)
@@ -1598,20 +2462,22 @@ class BaseInternals:
     ) -> None:
         didx = self.dinds[idx]
         assert didx >= 0
+        npos = len(self.all_positions)
         for i, trans in enumerate(self.internals['translations']):
-            if idx in trans.indices:
-                new_indices = (*trans.indices[:-1], didx)
-                new_trans = Translation(new_indices, trans.dim)
+            if idx in trans.indices and didx not in trans.indices:
+                new_indices = (*trans.indices, didx)
+                new_trans = Translation(new_indices, trans.kwargs['dim'])
                 self.internals['translations'][i] = new_trans
 
         for i, rot in enumerate(self.internals['rotations']):
-            if idx in rot.indices[:-1]:
-                new_indices = (*rot.indices[:-1], didx)
-                new_rot = Rotation(
-                    new_indices, rot.axis,
-                    self.all_positions[new_indices]
-                )
-                self.internals['rotations'][i] = new_rot
+            if idx in rot.indices and didx not in rot.indices:
+                new_indices = np.array((*rot.indices, didx), dtype=np.int32)
+                if np.all(new_indices < npos):
+                    new_rot = Rotation(
+                        new_indices, rot.kwargs['axis'],
+                        self.all_positions[new_indices]
+                    )
+                    self.internals['rotations'][i] = new_rot
 
     def check_all_gradients(
         self, delta: float = 1e-4, atol: float = 1e-6
@@ -1669,6 +2535,14 @@ class Constraints(BaseInternals):
         if self.ignore_rotation and self.nrotations:
             res[-self.nrotations:] = 0.
         return res
+
+    def has_inequalities(self) -> bool:
+        """Check if any inequality constraints (lt/gt) exist."""
+        for name in self._names:
+            for kind in self._kind[name]:
+                if kind in ('lt', 'gt'):
+                    return True
+        return False
 
     def disable_satisfied_inequalities(self) -> None:
         for name in self._names:
@@ -1941,6 +2815,7 @@ class Internals(BaseInternals):
             for coord in self.cons.internals[kind]:
                 adder(coord)
         self.allow_fragments = allow_fragments
+        self.fragment_atom_groups = None
 
     def copy(self) -> 'Internals':
         new = self.__class__(
@@ -1953,6 +2828,7 @@ class Internals(BaseInternals):
         )
         for name in self._names:
             new.internals[name] = self.internals[name].copy()
+            new._internals_set[name] = self._internals_set[name].copy()
             new.forbidden[name] = self.forbidden[name].copy()
             new._active[name] = self._active[name].copy()
         return new
@@ -2036,12 +2912,14 @@ class Internals(BaseInternals):
         else:
             ncvecs = self._get_ncvecs(indices, ncvecs, mic)
             new = kind(indices, ncvecs=ncvecs)
+        key = (tuple(new.indices), tuple(map(tuple, new.kwargs['ncvecs'])))
         if (
-            new in self.internals[name]
+            key in self._internals_set[name]
             or new in self.forbidden[name]
         ):
             raise DuplicateInternalError
         self.internals[name].append(new)
+        self._internals_set[name].add(key)
         self._active[name].append(True)
 
     add_bond = partialmethod(_add_internal, Bond, 'bonds')
@@ -2130,6 +3008,112 @@ class Internals(BaseInternals):
                 labels[j] = label
                 Internals.flood_fill(j, nbonds, c10y, labels, label)
 
+    def _find_bonds_vectorized(self, labels, scale, rcov):
+        """Vectorized bond search across all candidate atom pairs.
+
+        Returns a list of (i, j, ts) tuples for bonds that pass the
+        distance threshold, where ts is the integer translation vector.
+        """
+        natoms = self.natoms
+        pos = self.atoms.positions
+        cell = self.atoms.cell.array
+        pbc = self.atoms.pbc
+
+        # Ensure cell/rcell/op are cached
+        if self.cell is None or not np.allclose(self.cell, self.atoms.cell):
+            self.cell = self.atoms.cell.array.copy()
+            rcell, self.op = minkowski_reduce(
+                complete_cell(self.cell), pbc=pbc
+            )
+            self.rcell = Cell(rcell)
+            self._rcell_reciprocal_T = self.rcell.reciprocal().T
+
+        # 1. Generate all candidate pairs (i <= j)
+        ii, jj = np.triu_indices(natoms, k=0)
+        # Skip pairs in the same labeled fragment
+        same_frag = (labels[ii] == labels[jj]) & (labels[ii] != -1)
+        keep = ~same_frag
+        ii, jj = ii[keep], jj[keep]
+
+        if len(ii) == 0:
+            return []
+
+        # 2. All pairwise displacements
+        dx = pos[jj] - pos[ii]  # (n_pairs, 3)
+
+        # 3. Pair-dependent offsets (vectorized _get_neighbors logic)
+        dx_sc = dx @ self._rcell_reciprocal_T
+        offset = np.zeros(dx_sc.shape, dtype=np.int32)
+        for _ in range(2):
+            offset += (pbc * ((dx_sc - offset) // 1.)).astype(np.int32)
+
+        # 4. Base translation vectors from PBC dimensions
+        ranges = [np.arange(-1 * p, p + 1) for p in pbc]
+        base_ts = np.array(
+            list(product(*ranges)), dtype=np.int32
+        )  # (n_ts, 3)
+
+        # 5. Shifted translations and Cartesian vectors
+        shifted = base_ts[None, :, :] - offset[:, None, :]  # (n_pairs, n_ts, 3)
+        tvecs_cart = (shifted @ self.op) @ cell  # (n_pairs, n_ts, 3)
+
+        # 6. Distances
+        dists = np.linalg.norm(
+            dx[:, None, :] + tvecs_cart, axis=2
+        )  # (n_pairs, n_ts)
+
+        # 7. Covalent radius threshold
+        thresholds = scale * (rcov[ii] + rcov[jj])
+        bond_mask = dists <= thresholds[:, None]
+
+        # 8. Exclude self-bonds (i==j) with zero translation
+        self_bond = (ii == jj)
+        zero_ts = np.all(shifted @ self.op == 0, axis=2)
+        bond_mask &= ~(self_bond[:, None] & zero_ts)
+
+        # 9. Collect hits
+        pair_idx, ts_idx = np.nonzero(bond_mask)
+        op = self.op
+        results = []
+        for k in range(len(pair_idx)):
+            p = pair_idx[k]
+            t = ts_idx[k]
+            ts = (shifted[p, t] @ op).astype(np.int32)
+            results.append((int(ii[p]), int(jj[p]), ts))
+        return results
+
+    def _wrap_fragment_positions(self, group, cumshifts):
+        """Shift atom positions so fragment atoms are contiguous across PBC.
+
+        BFS from first atom in group, using bond ncvecs to bring each
+        bonded neighbor into the same periodic image. Accumulates shifts
+        along bond chains so molecules spanning multiple cell boundaries
+        are fully contracted. Records cumulative shifts in cumshifts dict
+        for subsequent ncvec correction.
+        """
+        group_set = set(group)
+        cell = np.asarray(self.atoms.cell)
+
+        adj = {i: [] for i in group}
+        for bond in self.internals['bonds']:
+            i, j = bond.indices
+            if i in group_set and j in group_set:
+                ncvec = bond.kwargs['ncvecs'][0]
+                adj[i].append((j, ncvec))
+                adj[j].append((i, -ncvec))
+
+        anchor = group[0]
+        cumshifts[anchor] = np.zeros(3, dtype=int)
+        queue = [anchor]
+        while queue:
+            i = queue.pop(0)
+            for j, ncvec in adj[i]:
+                if j in cumshifts:
+                    continue
+                cumshifts[j] = ncvec + cumshifts[i]
+                self.atoms.positions[j] += cumshifts[j] @ cell
+                queue.append(j)
+
     def find_all_bonds(
         self,
         nbond_cart_thr: int = 6,
@@ -2173,32 +3157,19 @@ class Internals(BaseInternals):
             if self.allow_fragments and not first_run:
                 break
 
-            for i, j in cwr(range(self.natoms), 2):
-                # do not add a bond between atoms belonging to the same
-                # bonding network fragment
-                if labels[i] == labels[j] and labels[i] != -1:
+            candidates = self._find_bonds_vectorized(
+                labels, scale, rcov
+            )
+            for i, j, ts in candidates:
+                try:
+                    self.add_bond((i, j), ts)
+                except DuplicateInternalError:
                     continue
-                dx = self.atoms.positions[j] - self.atoms.positions[i]
-                for ts in self._get_neighbors(dx):
-                    # self-bonding is only allowed if a non-zero periodic
-                    # translation vector is used
-                    if i == j and np.all(ts == np.array((0, 0, 0))):
-                        continue
-                    dist = np.linalg.norm(dx + ts @ self.atoms.cell)
-                    if dist <= scale * (rcov[i] + rcov[j]):
-                        # try to add the bond. it doesn't matter if the
-                        # bond already exists.
-                        try:
-                            self.add_bond((i, j), ts)
-                        except DuplicateInternalError:
-                            continue
-                        if nbonds[i] < max_bonds and nbonds[j] < max_bonds:
-                            c10y[i, nbonds[i]] = j
-                            nbonds[i] += 1
-                            c10y[j, nbonds[j]] = i
-                            nbonds[j] += 1
-                        else:
-                            pass
+                if nbonds[i] < max_bonds and nbonds[j] < max_bonds:
+                    c10y[i, nbonds[i]] = j
+                    nbonds[i] += 1
+                    c10y[j, nbonds[j]] = i
+                    nbonds[j] += 1
             first_run = False
             scale *= 1.05
 
@@ -2211,11 +3182,27 @@ class Internals(BaseInternals):
                     self.add_translation(i)
                 else:
                     groups[label].append(i)
+            cumshifts = {}
+            self.fragment_atom_groups = []
             for group in groups:
                 if not group:
                     continue
+                self._wrap_fragment_positions(group, cumshifts)
+                self.fragment_atom_groups.append(np.array(group, dtype=np.int32))
                 self.add_translation(group)
                 self.add_rotation(group)
+
+            # Update bond ncvecs to match the new wrapped positions.
+            # ncvec_new = ncvec_old - cumshift[j] + cumshift[i]
+            zero = np.zeros(3, dtype=int)
+            for bond in self.internals['bonds']:
+                i, j = bond.indices
+                shift_i = cumshifts.get(i, zero)
+                shift_j = cumshifts.get(j, zero)
+                if np.any(shift_i != 0) or np.any(shift_j != 0):
+                    bond.kwargs['ncvecs'] = np.array(
+                        [bond.kwargs['ncvecs'][0] - shift_j + shift_i]
+                    )
 
     def find_all_angles(
         self,
@@ -2276,6 +3263,7 @@ class Internals(BaseInternals):
                         # Add the dummy atom
                         dpos += self.atoms.positions[j]
                         self.dummies += Atom('X', dpos)
+                        self._batched_arrays_valid = False
                     # Create and fix dummy bond
                     dbond = Bond((j, self.dinds[j]))
                     self.cons.fix_bond(dbond, replace_ok=False)
@@ -2333,25 +3321,40 @@ class Internals(BaseInternals):
                             )
 
     def find_all_dihedrals(self) -> None:
-        # First, find proper dihedrals from angle combinations
-        for a1, a2 in combinations(self.internals['angles'], 2):
-            try:
-                new = a1 + a2
-            except NoValidInternalError:
-                continue
-            # this is a dihedral that has the same exact atom as both
-            # the first and last atom.
-            if (
-                new.indices[0] == new.indices[3]
-                and np.all(
-                    np.sum(new.kwargs['ncvecs'], axis=0) == np.array((0, 0, 0))
-                )
-            ):
-                continue
-            try:
-                self.add_dihedral(new)
-            except DuplicateInternalError:
-                continue
+        # First, find proper dihedrals from angle combinations.
+        # Group angles by their bond edges so we only try pairs that
+        # share a bond (required for __add__ to succeed).
+        edge_to_angles = {}
+        for angle in self.internals['angles']:
+            i, j, k = angle.indices
+            for edge_key in ((min(i, j), max(i, j)), (min(j, k), max(j, k))):
+                edge_to_angles.setdefault(edge_key, []).append(angle)
+
+        seen_pairs = set()
+        for angles_on_edge in edge_to_angles.values():
+            for a1, a2 in combinations(angles_on_edge, 2):
+                pair_key = (id(a1), id(a2))
+                if pair_key in seen_pairs:
+                    continue
+                seen_pairs.add(pair_key)
+                try:
+                    new = a1 + a2
+                except NoValidInternalError:
+                    continue
+                # this is a dihedral that has the same exact atom as both
+                # the first and last atom.
+                if (
+                    new.indices[0] == new.indices[3]
+                    and np.all(
+                        np.sum(new.kwargs['ncvecs'], axis=0)
+                        == np.array((0, 0, 0))
+                    )
+                ):
+                    continue
+                try:
+                    self.add_dihedral(new)
+                except DuplicateInternalError:
+                    continue
 
         # Second, add improper dihedrals for atoms with 3 or 4 neighbors that don't
         # have any proper dihedral passing through them. This is needed because:
@@ -2417,17 +3420,27 @@ class Internals(BaseInternals):
 
     def validate_basis(self) -> None:
         jac = self.jacobian()
-        U, S, VT = np.linalg.svd(jac)
+        S = svdvals(jac)
         ndeloc = np.sum(S > 1e-8)
 
-        # If TRICs (translations/rotations) are present, they span the full
-        # 3N DOF. Otherwise, 6 DOF are removed for global translation/rotation.
         has_trics = (len(self.internals['translations']) > 0 or
                      len(self.internals['rotations']) > 0)
         if has_trics:
             ndof = 3 * (self.natoms + self.ndummies)
         else:
-            ndof = 3 * (self.natoms + self.ndummies) - 6
+            ntot = self.natoms + self.ndummies
+            has_periodic_bonds = any(
+                np.any(bond.kwargs['ncvecs'] != 0)
+                for bond in self.internals['bonds']
+            )
+            if has_periodic_bonds:
+                ndof = 3 * ntot
+            elif ntot <= 1:
+                ndof = 0
+            elif ntot == 2:
+                ndof = 1
+            else:
+                ndof = 3 * ntot - 6
 
         if ndeloc != ndof:
             warnings.warn(
@@ -2450,7 +3463,7 @@ class Internals(BaseInternals):
         self._build_batched_arrays()
         if self._n_angles_actual > 0:
             positions = self.all_positions
-            cell = self.atoms.cell.array if hasattr(self.atoms.cell, 'array') else np.asarray(self.atoms.cell)
+            cell = self.atoms.cell.array
             tvecs = self._get_cached_tvecs(cell)
             angle_pos = positions[self._angle_indices_padded]
             angle_vals_padded = np.asarray(_angle_value_batched(angle_pos, tvecs['angles_padded']))
@@ -2539,8 +3552,12 @@ class Internals(BaseInternals):
         for angle in self.internals['angles']:
             h0[idx] = self._h0_angle(angle)
             idx += 1
+        dummy_set = set(range(self.natoms, self.natoms + self.ndummies))
         for dihedral in self.internals['dihedrals']:
-            h0[idx] = self._h0_dihedral(dihedral, nbonds)
+            if any(j in dummy_set for j in dihedral.indices):
+                h0[idx] = 0.5 * units.Hartree
+            else:
+                h0[idx] = self._h0_dihedral(dihedral, nbonds)
             idx += 1
         # remaining degrees of freedom are rotations.
         # No idea what a good curvature is for these

--- a/sella/internal.py
+++ b/sella/internal.py
@@ -541,7 +541,9 @@ def _rotation_q(
         [Ftop[:, None], -Rtr * jnp.eye(3) + R + R.T],
     ])
     q = eigh_rightmost(F)
-    return q * jnp.sign(q[0])
+    # Use where instead of sign: sign(0)=0 in JAX which zeros the entire
+    # quaternion for linear molecules, making all rotation Jacobians zero.
+    return q * jnp.where(q[0] >= 0, 1.0, -1.0)
 
 
 # "inverse sinc" function, naive, undefined at x=1
@@ -606,7 +608,7 @@ def _rotation_3axis_masked(
         [Ftop[:, None], -Rtr * jnp.eye(3) + R + R.T],
     ])
     q = eigh_rightmost(F)
-    q = q * jnp.sign(q[0])
+    q = q * jnp.where(q[0] >= 0, 1.0, -1.0)
     a = asinc(q[0])
     return jnp.stack([2 * q[1] * a, 2 * q[2] * a, 2 * q[3] * a])
 
@@ -715,6 +717,18 @@ class Rotation(Coordinate):
     _eval0 = staticmethod(jit(_rotation))
     _eval1 = staticmethod(jit(jacfwd(_rotation, argnums=0)))
     _eval2 = staticmethod(jit(jacfwd(jacfwd(_rotation, argnums=0), argnums=0)))
+
+    def calc_hessian(self, atoms: Atoms) -> jnp.ndarray:
+        result = np.array(self._eval2(
+            atoms.positions[self.indices], **self.kwargs
+        ))
+        # For linear molecules, the quaternion eigenvalue problem in
+        # _rotation_q has degenerate eigenvalues, producing NaN second
+        # derivatives. The corresponding rotation is physically
+        # meaningless (zero Jacobian), so replacing NaN with 0 is exact.
+        if np.any(np.isnan(result)):
+            np.nan_to_num(result, copy=False)
+        return result
 
 
 def _displacement(
@@ -1756,9 +1770,15 @@ class BaseInternals:
             atoms = self.light_atoms
             return [(r.indices, np.array(r.calc_hessian(atoms)))
                     for r in rotations]
-        hess_padded = np.asarray(device_get(_rotation_hess_padded_vmap(
+        hess_padded = np.array(device_get(_rotation_hess_padded_vmap(
             jnp.asarray(pos_pad), jnp.asarray(ref_pad), jnp.asarray(mask)
         )))
+        # For linear molecules, the quaternion eigenvalue problem has
+        # degenerate eigenvalues producing NaN second derivatives. The
+        # corresponding rotation is physically meaningless (zero Jacobian),
+        # so replacing NaN with 0 is exact.
+        if np.any(np.isnan(hess_padded)):
+            np.nan_to_num(hess_padded, copy=False)
         # hess_padded.shape == (n_frags, 3, N_max, 3, N_max, 3)
         out = [None] * len(rotations)
         for fi, slot in enumerate(slots):
@@ -3423,6 +3443,8 @@ class Internals(BaseInternals):
         S = svdvals(jac)
         ndeloc = np.sum(S > 1e-8)
 
+        # If TRICs (translations/rotations) are present, they span the full
+        # 3N DOF. Otherwise, 6 DOF are removed for global translation/rotation.
         has_trics = (len(self.internals['translations']) > 0 or
                      len(self.internals['rotations']) > 0)
         if has_trics:

--- a/sella/linalg.py
+++ b/sella/linalg.py
@@ -5,9 +5,10 @@ from itertools import product
 import numpy as np
 
 from sella.hessian_update import update_H
+from sella import _gpu as _gpu_mod
+from sella._gpu import gpu_eigh, gpu_eigh_t, to_gpu
 
 from scipy.sparse.linalg import LinearOperator
-from scipy.linalg import eigh
 
 
 class NumericalHessian(LinearOperator):
@@ -161,14 +162,50 @@ class ApproximateHessian(LinearOperator):
         self._evals = None
         self._evecs = None
         self._eigen_computed = False
+        # Lazy GPU upload of B, shared with downstream consumers
+        # (projection, etc.) so a single (N,N) transfer covers the step.
+        self._B_gpu = None
+        # Cached torch eigvals/eigvecs alongside the numpy versions, so the
+        # GPU-resident TS-BFGS update can read them without re-uploading.
+        self._evals_gpu = None
+        self._evecs_gpu = None
 
         self.set_B(B0)
 
     def _ensure_eigen_computed(self):
-        """Compute eigendecomposition if not already done."""
-        if not self._eigen_computed and self.B is not None:
-            self._evals, self._evecs = eigh(self.B)
-            self._eigen_computed = True
+        """Compute eigendecomposition if not already done.
+
+        Prefers the GPU-tensor path when B_gpu is cached so the eigvecs stay
+        on device for downstream consumers (e.g. _MS_TS_BFGS), while still
+        producing the numpy copies the rest of Sella expects.
+        """
+        if self._eigen_computed or self.B is None:
+            return
+        B_gpu = self._get_B_gpu()
+        if B_gpu is not None:
+            evals_t, evecs_t = gpu_eigh_t(B_gpu)
+            if evals_t is not None:
+                self._evals_gpu = evals_t
+                self._evecs_gpu = evecs_t
+                self._evals = evals_t.cpu().numpy()
+                self._evecs = evecs_t.cpu().numpy()
+                self._eigen_computed = True
+                return
+        # CPU fallback (no GPU or OOM)
+        self._evals, self._evecs = gpu_eigh(self.B, A_gpu=None)
+        self._eigen_computed = True
+
+    def _get_B_gpu(self):
+        """Return cached torch tensor of B on GPU, uploading lazily.
+
+        Returns None when no GPU is available, when B is below the size
+        threshold, or when an upload attempt has previously OOM'd.
+        """
+        if self.B is None:
+            return None
+        if self._B_gpu is None and _gpu_mod._gpu_ok(self.B.shape[0]):
+            self._B_gpu = to_gpu(self.B)
+        return self._B_gpu
 
     @property
     def evals(self):
@@ -200,6 +237,9 @@ class ApproximateHessian(LinearOperator):
             self._evals = None
             self._evecs = None
             self._eigen_computed = False
+            self._B_gpu = None
+            self._evals_gpu = None
+            self._evecs_gpu = None
             self.initialized = False
             return
         elif np.isscalar(target):
@@ -210,6 +250,27 @@ class ApproximateHessian(LinearOperator):
         self.B = target
         # Mark eigendecomposition as stale - will recompute on next access
         self._eigen_computed = False
+        # B has changed, so the GPU copies are stale. Don't re-upload eagerly:
+        # _get_B_gpu does it lazily on next read.
+        self._B_gpu = None
+        self._evals_gpu = None
+        self._evecs_gpu = None
+
+    def _set_from_gpu(self, B_numpy, B_gpu):
+        """Install (numpy, torch) copies of B that are already in sync.
+
+        Used by `update()` to avoid the round-trip when the GPU TS-BFGS path
+        produced both a numpy result and the same tensor on device.
+        """
+        assert B_numpy.shape == self.shape
+        self.B = B_numpy
+        self.initialized = True
+        self._B_gpu = B_gpu
+        self._eigen_computed = False
+        self._evals = None
+        self._evecs = None
+        self._evals_gpu = None
+        self._evecs_gpu = None
 
     def update(self, dx, dg):
         """Perform a quasi-Newton update on B"""
@@ -228,8 +289,20 @@ class ApproximateHessian(LinearOperator):
             self.set_B(B)
             return
 
-        self.set_B(update_H(B, dx, dg, method=self.update_method,
-                            symm=self.symm, lams=self.evals, vecs=self.evecs))
+        # Force GPU eig cache to populate alongside numpy lams/vecs (if a
+        # GPU is available); keeps update_H's GPU path eligible.
+        lams, vecs = self.evals, self.evecs
+
+        result = update_H(B, dx, dg, method=self.update_method,
+                          symm=self.symm, lams=lams, vecs=vecs,
+                          B_gpu=self._B_gpu,
+                          evals_gpu=self._evals_gpu,
+                          evecs_gpu=self._evecs_gpu)
+        if isinstance(result, tuple):
+            Bplus_numpy, Bplus_gpu = result
+            self._set_from_gpu(Bplus_numpy, Bplus_gpu)
+        else:
+            self.set_B(result)
 
     def project(self, U):
         """Project B into the subspace defined by U."""
@@ -395,80 +468,125 @@ class SparseInternalHessian(LinearOperator):
 # Uses np.einsum for batched matrix-vector products and np.add.at for scatter.
 # =============================================================================
 
-class SparseInternalHessians:
-    def __init__(
-        self,
-        hessians: List[SparseInternalHessian],
-        ndof: int
-    ):
-        self.hessians = hessians
-        self.natoms = ndof // 3
-        self.shape = (len(self.hessians), ndof, ndof)
-        # Pre-compute batched data structures for vectorized operations
-        self._prepare_batched_data()
+class SparseInternalHessiansSkeleton:
+    """Index-only data for SparseInternalHessians.
 
-    def _prepare_batched_data(self):
-        """Pre-compute index arrays for vectorized ldot and rdot operations."""
-        # Group hessians by size (number of atoms involved)
+    Holds the per-size groupings, atom-index arrays, and pre-computed flat
+    indices used by ldot/rdot. These derive only from the per-coord
+    ``indices`` and the global ``natoms`` — neither depends on the
+    coordinate Hessian *values* or atomic positions, so the skeleton can
+    be cached across optimizer steps and reused as long as the active
+    set of internal coordinates is unchanged.
+    """
+
+    def __init__(self, hessians: List[SparseInternalHessian], natoms: int):
+        self.natoms = natoms
+        self.n_hess = len(hessians)
+
+        # Group hessians by size (number of atoms involved).
         by_size = {}
-        for i, h in enumerate(self.hessians):
+        for i, h in enumerate(hessians):
             n = len(h.indices)
             if n not in by_size:
-                by_size[n] = {'orig_idx': [], 'indices': [], 'vals': []}
+                by_size[n] = {'orig_idx': [], 'indices': []}
             by_size[n]['orig_idx'].append(i)
             by_size[n]['indices'].append(h.indices)
-            by_size[n]['vals'].append(h.vals)
 
-        # Pre-compute the 3x3 index mesh for ldot
         i_idx, j_idx = np.meshgrid(np.arange(3), np.arange(3), indexing='ij')
         i_flat = i_idx.ravel()
         j_flat = j_idx.ravel()
 
-        self._batched_rdot = {}
-        self._batched_ldot = {}
+        # rdot only needs orig_idx + per-coord atom indices; vals are
+        # filled in per call by SparseInternalHessians.
+        self.rdot_meta = {}
+        # ldot also needs the precomputed flat 1D scatter index.
+        self.ldot_meta = {}
 
         for size, data in by_size.items():
             orig_idx = np.array(data['orig_idx'])
             indices = np.array(data['indices'])  # (batch, size)
-            vals = np.array(data['vals'])  # (batch, size, 3, size, 3)
             batch = len(orig_idx)
 
-            # For rdot: prepare gather/scatter indices
-            self._batched_rdot[size] = {
+            self.rdot_meta[size] = {
                 'orig_idx': orig_idx,
                 'indices': indices,
-                'vals': vals,
             }
 
-            # For ldot: prepare fully expanded index arrays
             n_pairs = size * size
-
-            # Create atom pair indices
             a_local, b_local = np.meshgrid(np.arange(size), np.arange(size), indexing='ij')
             a_local = a_local.ravel()
             b_local = b_local.ravel()
 
-            # Map to actual atom indices for each batch
             row_atoms = indices[:, a_local]  # (batch, size*size)
             col_atoms = indices[:, b_local]
-
-            # Expand for 3x3 blocks
             row_atoms = np.repeat(row_atoms, 9, axis=1)  # (batch, size*size*9)
             col_atoms = np.repeat(col_atoms, 9, axis=1)
             i_full = np.tile(i_flat, (batch, n_pairs))
             j_full = np.tile(j_flat, (batch, n_pairs))
 
-            # Reorder vals: (batch, size, 3, size, 3) -> (batch, size*size*9)
-            vals_reordered = vals.transpose(0, 1, 3, 2, 4)  # (batch, size, size, 3, 3)
-            vals_flat = vals_reordered.reshape(batch, -1)
+            # Pre-compute the flat 1D index used by the bincount-based ldot.
+            # M is (natoms, 3, natoms, 3); flat index =
+            # ((row*3 + i)*natoms + col)*3 + j.
+            linear_idx = ((row_atoms.ravel() * 3 + i_full.ravel())
+                          * natoms + col_atoms.ravel()) * 3 + j_full.ravel()
 
+            self.ldot_meta[size] = {
+                'orig_idx': orig_idx,
+                'linear_idx': linear_idx,
+                'batch': batch,
+                'n_pairs': n_pairs,
+            }
+
+
+class SparseInternalHessians:
+    def __init__(
+        self,
+        hessians: List[SparseInternalHessian],
+        ndof: int,
+        skeleton: 'SparseInternalHessiansSkeleton' = None,
+    ):
+        self.hessians = hessians
+        self.natoms = ndof // 3
+        self.shape = (len(self.hessians), ndof, ndof)
+
+        if skeleton is None:
+            skeleton = SparseInternalHessiansSkeleton(hessians, self.natoms)
+        elif skeleton.n_hess != len(hessians) or skeleton.natoms != self.natoms:
+            raise ValueError(
+                "skeleton was built for a different (n_hess, natoms); "
+                f"got skeleton ({skeleton.n_hess}, {skeleton.natoms}) vs "
+                f"this ({len(hessians)}, {self.natoms})"
+            )
+        self._skeleton = skeleton
+        self._build_value_views()
+
+    def _build_value_views(self):
+        """Stitch fresh per-coord vals onto the cached skeleton.
+
+        ``vals_flat`` is rebuilt on every call (it tracks atomic positions
+        via the per-coord Hessian values), but the index arrays are reused
+        from the skeleton.
+        """
+        hessians = self.hessians
+        self._batched_rdot = {}
+        self._batched_ldot = {}
+        for size, meta in self._skeleton.rdot_meta.items():
+            orig_idx = meta['orig_idx']
+            # Stack the current Hessian values for this size group.
+            vals = np.array([hessians[i].vals for i in orig_idx])
+            self._batched_rdot[size] = {
+                'orig_idx': orig_idx,
+                'indices': meta['indices'],
+                'vals': vals,
+            }
+            ldot_meta = self._skeleton.ldot_meta[size]
+            # Reorder vals: (batch, size, 3, size, 3) -> (batch, size*size*9)
+            vals_reordered = vals.transpose(0, 1, 3, 2, 4)
+            vals_flat = vals_reordered.reshape(ldot_meta['batch'], -1)
             self._batched_ldot[size] = {
                 'orig_idx': orig_idx,
                 'vals_flat': vals_flat,
-                'row_atoms': row_atoms,
-                'col_atoms': col_atoms,
-                'i_full': i_full,
-                'j_full': j_full,
+                'linear_idx': ldot_meta['linear_idx'],
             }
 
     def asarray(self) -> np.ndarray:
@@ -482,25 +600,23 @@ class SparseInternalHessians:
         return arr
 
     def ldot(self, v: np.ndarray) -> np.ndarray:
-        """Vectorized left dot: v^T @ D -> (ndof, ndof) matrix."""
-        M = np.zeros((self.natoms, 3, self.natoms, 3))
+        """Vectorized left dot: v^T @ D -> (ndof, ndof) matrix.
+
+        Uses np.bincount on a precomputed flat 1D index instead of np.add.at
+        on a 4D index. bincount handles duplicate indices in vectorized C
+        code, while np.add.at falls back to a Python-level loop for repeats.
+        On NACJAF (120 atoms, 72 constraints) this is ~2.5× faster.
+        """
+        n_dof = self.natoms * 3
+        M_flat = np.zeros(n_dof * n_dof)
 
         for size, data in self._batched_ldot.items():
-            orig_idx = data['orig_idx']
-            vals_flat = data['vals_flat']
-            row_atoms = data['row_atoms']
-            col_atoms = data['col_atoms']
-            i_full = data['i_full']
-            j_full = data['j_full']
+            weights = v[data['orig_idx']]
+            weighted = (data['vals_flat'] * weights[:, None]).ravel()
+            M_flat += np.bincount(data['linear_idx'], weights=weighted,
+                                  minlength=n_dof * n_dof)
 
-            weights = v[orig_idx]
-            weighted = vals_flat * weights[:, None]
-
-            np.add.at(M, (row_atoms.ravel(), i_full.ravel(),
-                         col_atoms.ravel(), j_full.ravel()),
-                      weighted.ravel())
-
-        return M.reshape(self.shape[1:])
+        return M_flat.reshape((n_dof, n_dof))
 
     def rdot(self, v: np.ndarray) -> np.ndarray:
         """Vectorized right dot: D @ v -> (nhess, ndof) matrix."""

--- a/sella/optimize/optimize.py
+++ b/sella/optimize/optimize.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import logging
 import warnings
 from time import localtime, strftime
 from typing import Union, Callable, Optional
@@ -10,9 +11,11 @@ from ase.optimize.optimize import Optimizer
 from ase.utils import basestring
 from ase.io.trajectory import Trajectory
 
-from .restricted_step import get_restricted_step
-from sella.peswrapper import PES, InternalPES
+from .restricted_step import get_restricted_step, MaxInternalStep
+from sella.peswrapper import PES, InternalPES, CellInternalPES, CellCartesianPES
 from sella.internal import Internals, Constraints
+
+logger = logging.getLogger(__name__)
 
 _default_kwargs = dict(
     minimum=dict(
@@ -64,12 +67,76 @@ class Sella(Optimizer):
         nsteps_per_diag: int = 3,
         diag_every_n: Optional[int] = None,
         hessian_function: Optional[Callable[[Atoms], np.ndarray]] = None,
+        optimize_cell: bool = False,
+        cell_mask: np.ndarray = None,
+        exp_cell_factor: float = None,
+        scalar_pressure: float = 0.0,
+        smax: float = None,
+        allow_fragments: bool = False,
+        niggli: bool = False,
+        refine_initial_hessian: Union[bool, int] = False,
+        save_hessian: str = None,
         **kwargs
     ):
+        """Initialize Sella optimizer.
+
+        Parameters
+        ----------
+        atoms : Atoms
+            ASE Atoms object to optimize.
+        optimize_cell : bool, optional
+            If True, optimize unit cell parameters along with atomic positions.
+            Requires order=0. Default is False.
+        cell_mask : ndarray, optional
+            Boolean mask of shape (3, 3) indicating which cell DOF are free.
+            Default is all True (full cell optimization).
+        exp_cell_factor : float, optional
+            Scaling factor for cell parameterization. Default is number of atoms.
+        scalar_pressure : float, optional
+            External pressure in eV/Å³ for cell optimization. Default is 0.
+        smax : float, optional
+            Maximum stress tolerance for convergence when optimize_cell=True.
+            If None, uses fmax.
+        allow_fragments : bool, optional
+            If True, allow disconnected molecular fragments when using internal
+            coordinates. Adds translation and rotation coordinates (TRICs) for
+            each fragment. Useful for molecular crystals. Default is False.
+        niggli : bool, optional
+            If True, apply Niggli reduction during cell optimization when cell
+            angles deviate more than 30 deg from 90 deg. This remaps to the
+            most compact unit cell and resets the Hessian cell block.
+            Default is False.
+        refine_initial_hessian : bool or int, optional
+            Level of Hessian refinement via finite differences:
+            - False or 0: No refinement (default)
+            - True or 1: Refine cell-related blocks only (2 * n_cell_dof force calls)
+            - 2: Also refine translation/rotation blocks for molecular crystals
+              (adds 2 * n_tric force calls, where n_tric = n_fragments * 6)
+            - 3: Refine full internal Hessian (2 * n_internal force calls, expensive!)
+        save_hessian : str, optional
+            Path to save the initial Hessian as .npy file for analysis.
+        """
         if order == 0:
             default = _default_kwargs['minimum']
         else:
             default = _default_kwargs['saddle']
+
+        # Validate cell optimization parameters
+        self.optimize_cell = optimize_cell
+        self.allow_fragments = allow_fragments
+        self.niggli = niggli
+        self.smax = smax
+        if optimize_cell:
+            if order != 0:
+                raise ValueError(
+                    "Cell optimization is only supported for minima (order=0), "
+                    f"got order={order}."
+                )
+            if not np.any(atoms.pbc):
+                raise ValueError(
+                    "Cell optimization requires periodic boundary conditions. "
+                    "Set atoms.pbc = True for periodic systems."
+                )
 
         if trajectory is not None:
             if isinstance(trajectory, basestring):
@@ -91,6 +158,13 @@ class Sella(Optimizer):
             v0,
             internal,
             hessian_function,
+            optimize_cell=optimize_cell,
+            cell_mask=cell_mask,
+            exp_cell_factor=exp_cell_factor,
+            scalar_pressure=scalar_pressure,
+            allow_fragments=allow_fragments,
+            refine_initial_hessian=refine_initial_hessian,
+            save_hessian=save_hessian,
             **kwargs
         )
 
@@ -107,36 +181,14 @@ class Sella(Optimizer):
             self.delta = delta0
         else:
             self.delta = delta0 * self.pes.get_Ufree().shape[1]
+        self.delta_cell = delta0
 
-        if sigma_inc is None:
-            self.sigma_inc = default['sigma_inc']
-        else:
-            self.sigma_inc = sigma_inc
-
-        if sigma_dec is None:
-            self.sigma_dec = default['sigma_dec']
-        else:
-            self.sigma_dec = sigma_dec
-
-        if rho_inc is None:
-            self.rho_inc = default['rho_inc']
-        else:
-            self.rho_inc = rho_inc
-
-        if rho_dec is None:
-            self.rho_dec = default['rho_dec']
-        else:
-            self.rho_dec = rho_dec
-
-        if method is None:
-            self.method = default['method']
-        else:
-            self.method = method
-
-        if eig is None:
-            self.eig = default['eig']
-        else:
-            self.eig = eig
+        self.sigma_inc = sigma_inc if sigma_inc is not None else default['sigma_inc']
+        self.sigma_dec = sigma_dec if sigma_dec is not None else default['sigma_dec']
+        self.rho_inc = rho_inc if rho_inc is not None else default['rho_inc']
+        self.rho_dec = rho_dec if rho_dec is not None else default['rho_dec']
+        self.method = method if method is not None else default['method']
+        self.eig = eig if eig is not None else default['eig']
 
         self.ord = order
         self.eta = eta
@@ -153,6 +205,10 @@ class Sella(Optimizer):
         self.initialized = False
         self.xi = 1.
         self.nsteps_per_diag = nsteps_per_diag
+
+        # Set by run() / first converged() call.
+        self.fmax = None
+        self._last_converged = None
         self.nsteps_since_diag = 0
         self.diag_every_n = np.inf if diag_every_n is None else diag_every_n
 
@@ -166,6 +222,13 @@ class Sella(Optimizer):
         v0: np.ndarray = None,
         internal: Union[bool, Internals] = False,
         hessian_function: Optional[Callable[[Atoms], np.ndarray]] = None,
+        optimize_cell: bool = False,
+        cell_mask: np.ndarray = None,
+        exp_cell_factor: float = None,
+        scalar_pressure: float = 0.0,
+        allow_fragments: bool = False,
+        refine_initial_hessian: Union[bool, int] = False,
+        save_hessian: str = None,
         **kwargs
     ):
         if internal:
@@ -180,25 +243,63 @@ class Sella(Optimizer):
                     )
             else:
                 auto_find_internals = True
-                internal = Internals(atoms, cons=constraints)
+                internal = Internals(
+                    atoms, cons=constraints, allow_fragments=allow_fragments,
+                )
             self.internal = internal.copy()
             self.constraints = None
-            self.pes = InternalPES(
-                atoms,
-                internals=internal,
-                trajectory=trajectory,
-                eta=eta,
-                v0=v0,
-                auto_find_internals=auto_find_internals,
-                hessian_function=hessian_function,
-                **kwargs
-            )
+
+            if optimize_cell:
+                # Use CellInternalPES for combined internal + cell optimization
+                self.pes = CellInternalPES(
+                    atoms,
+                    internals=internal,
+                    trajectory=trajectory,
+                    eta=eta,
+                    v0=v0,
+                    auto_find_internals=auto_find_internals,
+                    hessian_function=hessian_function,
+                    exp_cell_factor=exp_cell_factor,
+                    cell_mask=cell_mask,
+                    scalar_pressure=scalar_pressure,
+                    refine_initial_hessian=refine_initial_hessian,
+                    save_hessian=save_hessian,
+                    **kwargs
+                )
+            else:
+                self.pes = InternalPES(
+                    atoms,
+                    internals=internal,
+                    trajectory=trajectory,
+                    eta=eta,
+                    v0=v0,
+                    auto_find_internals=auto_find_internals,
+                    hessian_function=hessian_function,
+                    **kwargs
+                )
         else:
             self.internal = None
             if constraints is None:
                 constraints = Constraints(atoms)
             self.constraints = constraints
-            self.pes = PES(
+            if optimize_cell:
+                # Use CellCartesianPES for Cartesian + cell optimization
+                self.pes = CellCartesianPES(
+                    atoms,
+                    constraints=constraints,
+                    trajectory=trajectory,
+                    eta=eta,
+                    v0=v0,
+                    hessian_function=hessian_function,
+                    exp_cell_factor=exp_cell_factor,
+                    cell_mask=cell_mask,
+                    scalar_pressure=scalar_pressure,
+                    refine_initial_hessian=refine_initial_hessian,
+                    save_hessian=save_hessian,
+                    **kwargs
+                )
+            else:
+                self.pes = PES(
                 atoms,
                 constraints=constraints,
                 trajectory=trajectory,
@@ -223,17 +324,32 @@ class Sella(Optimizer):
         self.pes.cons.disable_satisfied_inequalities()
         self.pes._update_basis()
         self.pes.save()
-        all_valid = False
         x0 = self.pes.get_x()
-        while not all_valid:
-            s, smag = self.rs(
-                self.pes, self.ord, self.delta, method=self.method
-            ).get_s()
-            self.pes.set_x(x0 + s)
-            all_valid = self.pes.cons.validate_inequalities()
+
+        rs_kwargs = {}
+        if self.optimize_cell and isinstance(self.rs, type) and issubclass(
+            self.rs, MaxInternalStep
+        ):
+            rs_kwargs['wc'] = self.delta / self.delta_cell
+
+        if self.pes.cons.has_inequalities():
+            all_valid = False
+            while not all_valid:
+                s, smag = self.rs(
+                    self.pes, self.ord, self.delta, method=self.method,
+                    **rs_kwargs
+                ).get_s()
+                self.pes.set_x(x0 + s)
+                all_valid = self.pes.cons.validate_inequalities()
+                self.pes._update_basis()
+                self.pes.restore()
             self.pes._update_basis()
-            self.pes.restore()
-        self.pes._update_basis()
+        else:
+            s, smag = self.rs(
+                self.pes, self.ord, self.delta, method=self.method,
+                **rs_kwargs
+            ).get_s()
+
         return s, smag
 
     def step(self):
@@ -247,7 +363,7 @@ class Sella(Optimizer):
                 ev = True
             else:
                 Unred = self.pes.get_Unred()
-                ev = (self.pes.get_HL().project(Unred)
+                ev = (self.pes.get_HL_projected(Unred)
                                        .evals[:self.ord] > 0).any()
         else:
             ev = False
@@ -262,6 +378,14 @@ class Sella(Optimizer):
         # Check for bad internals, and if found, reset PES object.
         # This skips the trust radius update.
         if self.internal and self.pes.int.check_for_bad_internals():
+            if isinstance(self.pes, CellInternalPES):
+                cell_mask = self.pes.cell_mask
+                exp_cell_factor = self.pes.exp_cell_factor
+                scalar_pressure = self.pes.scalar_pressure
+            else:
+                cell_mask = None
+                exp_cell_factor = None
+                scalar_pressure = 0.0
             self.initialize_pes(
                 atoms=self.pes.atoms,
                 trajectory=self.pes.traj,
@@ -271,40 +395,104 @@ class Sella(Optimizer):
                 v0=None,  # TODO: use leftmost eigenvector from old H
                 internal=self.user_internal,
                 hessian_function=self.pes.hessian_function,
+                optimize_cell=self.optimize_cell,
+                cell_mask=cell_mask,
+                exp_cell_factor=exp_cell_factor,
+                scalar_pressure=scalar_pressure,
+                allow_fragments=self.allow_fragments,
             )
             self.initialized = False
             self.rho = 1
             return
 
         # Update trust radius
-        if rho is None:
-            pass
-        elif rho < 1./self.rho_dec or rho > self.rho_dec:
-            self.delta = max(smag * self.sigma_dec, self.delta_min)
-        elif 1./self.rho_inc < rho < self.rho_inc:
-            self.delta = max(self.sigma_inc * smag, self.delta)
-        self.rho = rho
-        if self.rho is None:
+        if rho is not None:
+            if self.optimize_cell and isinstance(self.pes, CellInternalPES):
+                n_int = self.pes.n_internal
+                smag_int = np.max(np.abs(s[:n_int])) if n_int > 0 else 0
+                smag_cell = np.max(np.abs(s[n_int:])) if len(s) > n_int else 0
+            else:
+                smag_int = smag
+                smag_cell = 0
+
+            if rho < 1./self.rho_dec or rho > self.rho_dec:
+                self.delta = max(smag_int * self.sigma_dec, self.delta_min)
+                if smag_cell > 0:
+                    self.delta_cell = max(self.delta_cell * self.sigma_dec,
+                                          self.delta_min)
+            elif 1./self.rho_inc < rho < self.rho_inc:
+                self.delta = max(self.sigma_inc * smag_int, self.delta)
+                if smag_cell > 0:
+                    self.delta_cell = max(self.sigma_inc * smag_cell,
+                                          self.delta_cell)
+            self.rho = rho
+        else:
             self.rho = 1.
 
+        # Apply Niggli reduction if cell becomes too skewed
+        if self.optimize_cell and self.niggli and self.pes.maybe_niggli_reduce():
+            logger.info("Applied Niggli reduction to reduce cell skewness")
+            self.initialized = False
+            self.rho = 1.
+
+    def gradient_converged(self, gradient=None):
+        return self.converged()
+
     def converged(self, forces=None):
-        return self.pes.converged(self.fmax)[0]
+        # fmax may still be None if converged() is called before run()
+        fmax = self.fmax if self.fmax is not None else 0.05  # Default threshold
+        if self.optimize_cell:
+            smax = self.smax if self.smax is not None else fmax
+            result = self.pes.converged(fmax, smax=smax)
+            self._last_converged = result
+            return result[0]
+        result = self.pes.converged(fmax)
+        self._last_converged = result
+        return result[0]
 
     def log(self, forces=None):
         if self.logfile is None:
             return
-        _, fmax, cmax = self.pes.converged(self.fmax)
-        e = self.pes.get_f()
-        T = strftime("%H:%M:%S", localtime())
-        name = self.__class__.__name__
-        buf = " " * len(name)
-        if self.nsteps == 0:
-            self.logfile.write(buf + "{:>4s} {:>8s} {:>15s} {:>12s} {:>12s} "
-                               "{:>12s} {:>12s}\n"
-                               .format("Step", "Time", "Energy", "fmax",
-                                       "cmax", "rtrust", "rho"))
-        self.logfile.write("{} {:>3d} {:>8s} {:>15.6f} {:>12.4f} {:>12.4f} "
-                           "{:>12.4f} {:>12.4f}\n"
-                           .format(name, self.nsteps, T, e, fmax, cmax,
-                                   self.delta, self.rho))
-        self.logfile.flush()
+        if self.optimize_cell:
+            smax = self.smax if self.smax is not None else self.fmax
+            result = self._last_converged
+            if result is None or len(result) != 4:
+                result = self.pes.converged(self.fmax, smax=smax)
+            _, fmax, cmax, smax_actual = result
+            e = self.pes.get_f()
+            T = strftime("%H:%M:%S", localtime())
+            name = self.__class__.__name__
+            buf = " " * len(name)
+            if self.nsteps == 0:
+                self.logfile.write(buf + "{:>4s} {:>8s} {:>15s} {:>12s} {:>12s} "
+                                   "{:>12s} {:>12s} {:>12s} {:>12s}\n"
+                                   .format("Step", "Time", "Energy", "fmax",
+                                           "smax", "cmax", "rtrust",
+                                           "strust", "rho"))
+            self.logfile.write("{} {:>3d} {:>8s} {:>15.6f} {:>12.4f} {:>12.4f} "
+                               "{:>12.4f} {:>12.4f} {:>12.4f} {:>12.4f}\n"
+                               .format(name, self.nsteps, T, e, fmax, smax_actual,
+                                       cmax, self.delta, self.delta_cell,
+                                       self.rho))
+        else:
+            result = self._last_converged
+            if result is None or len(result) != 3:
+                result = self.pes.converged(self.fmax)
+            _, fmax, cmax = result
+            e = self.pes.get_f()
+            T = strftime("%H:%M:%S", localtime())
+            name = self.__class__.__name__
+            buf = " " * len(name)
+            if self.nsteps == 0:
+                self.logfile.write(buf + "{:>4s} {:>8s} {:>15s} {:>12s} {:>12s} "
+                                   "{:>12s} {:>12s}\n"
+                                   .format("Step", "Time", "Energy", "fmax",
+                                           "cmax", "rtrust", "rho"))
+            self.logfile.write("{} {:>3d} {:>8s} {:>15.6f} {:>12.4f} {:>12.4f} "
+                               "{:>12.4f} {:>12.4f}\n"
+                               .format(name, self.nsteps, T, e, fmax, cmax,
+                                       self.delta, self.rho))
+        try:
+            self.logfile.flush()
+        except (AttributeError, TypeError):
+            pass

--- a/sella/optimize/restricted_step.py
+++ b/sella/optimize/restricted_step.py
@@ -17,7 +17,7 @@ class BaseRestrictedStep:
         order: int,
         delta: float,
         method: str = 'qn',
-        tol: float = 1e-15,
+        tol: float = None,
         maxiter: int = 1000,
         d1: Optional[np.ndarray] = None,
         W: Optional[np.ndarray] = None,
@@ -27,8 +27,10 @@ class BaseRestrictedStep:
         self.d1 = d1
         g0 = self.pes.get_g()
 
-        if W is None:
-            W = np.eye(len(g0))
+        # W defaults to the identity, in which case Ufree.T @ W == Ufree.T.
+        # Skip allocating an n_dof x n_dof eye for the (very common)
+        # default case to avoid quadratic zero-fill on large systems.
+        self._W_is_identity = (W is None)
 
         self.scons = self.pes.get_scons()
         # TODO: Should this be HL instead of H?
@@ -45,17 +47,22 @@ class BaseRestrictedStep:
             self.stepper = NaiveStepper(dx)
             self.scons[:] *= 0
         else:
-            self.P = self.pes.get_Ufree().T @ W
+            if self._W_is_identity:
+                self.P = self.pes.get_Ufree().T
+            else:
+                self.P = self.pes.get_Ufree().T @ W
             d1 = self.d1
             if d1 is not None:
                 d1 = np.linalg.lstsq(self.P.T, d1, rcond=None)[0]
             self.stepper = stepper(
                 self.P @ g,
-                self.pes.get_HL().project(self.P.T),
+                self.pes.get_HL_projected(self.P.T),
                 order,
                 d1=d1,
             )
 
+        if tol is None:
+            tol = 1e-10 if self.stepper.newton_safe else 1e-15
         self.tol = tol
         self.maxiter = maxiter
 
@@ -93,7 +100,9 @@ class BaseRestrictedStep:
                 lower = alpha
 
             a1 = alpha - err / dval
-            if np.isnan(a1) or a1 <= lower or a1 >= upper or niter > 4:
+            if np.isnan(a1) or a1 <= lower or a1 >= upper or (
+                niter > 4 and not self.stepper.newton_safe
+            ):
                 a2 = (lower + upper) / 2.
                 if np.isinf(a2):
                     alpha = alpha + max(1, 0.5 * alpha) * np.sign(a2)
@@ -178,7 +187,7 @@ class MaxInternalStep(BaseRestrictedStep):
     synonyms = ['mis', 'max internal step']
 
     def __init__(
-        self, pes, *args, wx=1., wb=1., wa=1., wd=1., wo=1., **kwargs
+        self, pes, *args, wx=1., wb=1., wa=1., wd=1., wo=1., wc=1., **kwargs
     ):
         if pes.int is None:
             raise ValueError(
@@ -190,17 +199,12 @@ class MaxInternalStep(BaseRestrictedStep):
         self.wa = wa
         self.wd = wd
         self.wo = wo
+        self.wc = wc  # Weight for cell DOF
+        self._weights_cache = None
         BaseRestrictedStep.__init__(self, pes, *args, **kwargs)
 
     def cons(self, s, dsda=None):
-        w = np.array(
-            [self.wx] * self.pes.int.ntrans
-            + [self.wb] * self.pes.int.nbonds
-            + [self.wa] * self.pes.int.nangles
-            + [self.wd] * self.pes.int.ndihedrals
-            + [self.wo] * self.pes.int.nother
-            + [self.wx] * self.pes.int.nrotations
-        )
+        w = self._get_weights()
         assert len(w) == len(s)
 
         sw = np.abs(s * w)
@@ -210,6 +214,33 @@ class MaxInternalStep(BaseRestrictedStep):
         if dsda is None:
             return val
         return val, np.sign(s[idx]) * dsda[idx] * w[idx]
+
+    def _get_weights(self):
+        """Build the per-DOF weight vector. Cached against
+        (counts, weights, n_cell_dof) so the np.array construction
+        only runs once per restricted-step instance."""
+        cached = self._weights_cache
+        n_cell_dof = self.pes.n_cell_dof
+        key = (
+            self.pes.int.ntrans, self.pes.int.nbonds,
+            self.pes.int.nangles, self.pes.int.ndihedrals,
+            self.pes.int.nother, self.pes.int.nrotations,
+            n_cell_dof,
+        )
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        w = np.array(
+            [self.wx] * self.pes.int.ntrans
+            + [self.wb] * self.pes.int.nbonds
+            + [self.wa] * self.pes.int.nangles
+            + [self.wd] * self.pes.int.ndihedrals
+            + [self.wo] * self.pes.int.nother
+            + [self.wx] * self.pes.int.nrotations
+        )
+        if n_cell_dof > 0:
+            w = np.concatenate([w, [self.wc] * n_cell_dof])
+        self._weights_cache = (key, w)
+        return w
 
 
 _all_restricted_step = [TrustRegion, RestrictedAtomicStep, MaxInternalStep]

--- a/sella/optimize/stepper.py
+++ b/sella/optimize/stepper.py
@@ -13,6 +13,8 @@ class BaseStepper:
     alphamax: Optional[float] = None
     # Whether the step size increases or decreases with increasing alpha
     slope: Optional[float] = None
+    # Whether get_s is smooth enough for Newton to converge reliably
+    newton_safe: bool = True
     synonyms: List[str] = []
 
     def __init__(
@@ -114,6 +116,7 @@ class RationalFunctionOptimization(BaseStepper):
     alphamin = 0.
     alphamax = 1.
     slope = 1.
+    newton_safe = False
     synonyms = ['rfo', 'rational function optimization']
 
     def _stepper_init(self) -> None:
@@ -144,7 +147,9 @@ class RationalFunctionOptimization(BaseStepper):
         L_diff = np.where(L_diff >= 0,
                          np.maximum(L_diff, 1e-12),
                          np.minimum(L_diff, -1e-12))
-        dVda = V1 @ ((V1.T @ dAda @ V[:, self.order]) / L_diff)
+        # Reassociate to do two matvecs (V1.T @ dAda is otherwise a (k-1, k)
+        # matmul that costs ~25× more for the same final vector result).
+        dVda = V1 @ ((V1.T @ (dAda @ V[:, self.order])) / L_diff)
 
         dsda = (V[:-1, self.order] / denom
                 + (alpha / denom) * dVda[:-1]

--- a/sella/peswrapper.py
+++ b/sella/peswrapper.py
@@ -1303,3 +1303,1618 @@ def full_3x3_to_voigt_6_stress(stress_3x3: np.ndarray) -> np.ndarray:
     ])
 
 
+class CellInternalPES(InternalPES):
+    """Internal coordinate PES with unit cell optimization.
+
+    This class extends InternalPES to simultaneously optimize both internal
+    coordinates (bonds, angles, dihedrals) and the unit cell parameters.
+
+    The cell is parameterized using the log of the deformation gradient:
+        F = cell @ inv(orig_cell)
+        cell_params = _logm_3x3(F) * exp_cell_factor
+
+    This parameterization ensures that:
+    1. The identity corresponds to zero cell parameters
+    2. Small deformations are approximately linear in the parameters
+    3. Large deformations are handled smoothly
+
+    Parameters
+    ----------
+    atoms : Atoms
+        ASE Atoms object with periodic boundary conditions.
+    internals : Internals
+        Internal coordinate system definition.
+    exp_cell_factor : float, optional
+        Scaling factor for cell parameterization. Default is number of atoms.
+    cell_mask : ndarray, optional
+        Boolean mask of shape (3, 3) indicating which cell DOF are free.
+        Default is all True (full cell optimization).
+    scalar_pressure : float, optional
+        External pressure in eV/Å³. Default is 0.
+    rigid_fragments : bool, optional
+        If True, cell changes translate fragment centers of mass to maintain
+        fractional CoM positions while preserving intramolecular geometry.
+        Auto-detected: defaults to True when internals have translations
+        (allow_fragments=True), else False.
+    refine_initial_hessian : bool, optional
+        If True, compute cell-coordinate coupling and cell-cell Hessian blocks
+        via finite differences. This requires additional force evaluations
+        (2 * n_cell_dof) but can improve convergence for coupled systems.
+        Default is False.
+    hessian_delta : float, optional
+        Finite difference step size for Hessian refinement. Default is 1e-5.
+    """
+
+    def __init__(
+        self,
+        atoms: Atoms,
+        internals: Internals,
+        *args,
+        exp_cell_factor: float = None,
+        cell_mask: np.ndarray = None,
+        scalar_pressure: float = 0.0,
+        rigid_fragments: bool = None,
+        refine_initial_hessian: Union[bool, int] = False,
+        hessian_delta: float = 1e-5,
+        save_hessian: str = None,
+        H0: np.ndarray = None,
+        **kwargs
+    ):
+        """Initialize CellInternalPES.
+
+        Parameters
+        ----------
+        rigid_fragments : bool, optional
+            If True, cell changes translate fragment centers of mass to maintain
+            fractional CoM positions while preserving intramolecular geometry.
+            This zeroes out cell-intramolecular Hessian coupling while keeping
+            physical cell-TRIC coupling. Auto-detected: defaults to True when
+            internals have translations (allow_fragments=True), else False.
+        refine_initial_hessian : bool or int
+            Level of Hessian refinement via finite differences:
+            - False or 0: No refinement (default)
+            - True or 1: Refine cell-related blocks only (2 * n_cell_dof evals)
+            - 2: Also refine translation/rotation blocks (adds 2 * n_tric evals)
+            - 3: Refine full internal Hessian (2 * n_internal evals, expensive!)
+        save_hessian : str, optional
+            Path to save the initial Hessian as .npy file for analysis.
+        """
+        # Store original cell as reference before any optimization
+        self.orig_cell = atoms.get_cell().array.copy()
+
+        # Cell parameterization scaling (like ASE's FrechetCellFilter)
+        if exp_cell_factor is None:
+            exp_cell_factor = float(len(atoms))
+        self.exp_cell_factor = exp_cell_factor
+
+        # Cell mask: which of the 9 cell matrix elements are free
+        if cell_mask is None:
+            cell_mask = np.ones((3, 3), dtype=bool)
+        self.cell_mask = np.asarray(cell_mask, dtype=bool).reshape((3, 3))
+        self.n_cell_dof = int(self.cell_mask.sum())
+
+        # External pressure
+        self.scalar_pressure = scalar_pressure
+
+        # Store rigid_fragments request; auto-detection deferred until after
+        # parent init populates translations via find_all_bonds()
+        self._rigid_fragments_request = rigid_fragments
+
+        # Flag to control get_x behavior during parent initialization
+        # When True, get_x returns only internal coords (for parent __init__)
+        self._initializing = True
+        self.n_internal = None  # Will be set by parent
+
+        # Initialize parent class - this will set up internal coords
+        # (including finding bonds/angles/translations if auto_find_internals)
+        InternalPES.__init__(self, atoms, internals, *args, H0=H0, **kwargs)
+
+        # Now parent is initialized. Store internal-only dimension.
+        self.n_internal = self.dim  # Parent set dim to internal coords count
+
+        # Rigid fragment mode: auto-detect from translations in internals
+        # (must be after parent init, which calls find_all_bonds and adds translations)
+        if self._rigid_fragments_request is None:
+            self.rigid_fragments = bool(self.int.internals.get('translations', []))
+        else:
+            self.rigid_fragments = self._rigid_fragments_request
+
+        if self.rigid_fragments:
+            # Extract fragment atom groups from Translation coordinates
+            self.fragment_groups, self.fragment_dummy_groups = \
+                self._extract_fragment_groups(self.int)
+
+        # Update dimension to include cell DOF
+        self.dim = self.n_internal + self.n_cell_dof
+
+        # Cache for the cell-extended constraint Hessian (separate from the
+        # parent's internal-only _Hc_cache).
+        self._Hc_cell_cache = _LRU2()
+
+        # Cache for the cell-extended basis (parent's _basis_cache only covers
+        # the internal-coords-only basis; CellInternalPES._calc_basis adds the
+        # cell-DOF zero-padding which we cache here).
+        self._cell_basis_cache = _LRU2()
+
+        # Done initializing - now get_x returns full vector
+        self._initializing = False
+
+        # Create proper Hessian with correct dimensions
+        # Use block-diagonal structure: internal Hessian + cell Hessian
+        H_old = self.H.B if self.H is not None and self.H.B is not None else None
+
+        # Pad internal Hessian and add cell block
+        H0_full = np.zeros((self.dim, self.dim))
+        if H_old is not None:
+            H0_full[:self.n_internal, :self.n_internal] = H_old
+        else:
+            B = self.int.jacobian()
+            Q, _ = qr(B, mode='economic')
+            P = Q @ Q.T
+            H_internal = P @ self.int.guess_hessian() @ P
+            H0_full[:self.n_internal, :self.n_internal] = H_internal
+
+        # Convert bool to int for refinement level
+        if refine_initial_hessian is True:
+            refine_level = 1
+        elif refine_initial_hessian is False:
+            refine_level = 0
+        else:
+            refine_level = int(refine_initial_hessian)
+
+        if refine_level >= 1:
+            # Level 1: Refine cell-related blocks
+            H_cell_cols = self._compute_cell_hessian_columns(hessian_delta)
+            # Set internal-cell coupling (and its transpose for symmetry)
+            H0_full[:self.n_internal, self.n_internal:] = H_cell_cols[:self.n_internal, :]
+            H0_full[self.n_internal:, :self.n_internal] = H_cell_cols[:self.n_internal, :].T
+            # Set cell-cell block with explicit symmetrization
+            H_cell_cell = H_cell_cols[self.n_internal:, :]
+            H0_full[self.n_internal:, self.n_internal:] = (H_cell_cell + H_cell_cell.T) / 2
+
+        if refine_level >= 2:
+            # Level 2: Also refine translation and rotation blocks
+            H_tric_cols = self._compute_tric_hessian_columns(hessian_delta)
+            tric_indices = self._get_tric_indices()
+            for i, idx in enumerate(tric_indices):
+                H0_full[:, idx] = H_tric_cols[:, i]
+                H0_full[idx, :] = H_tric_cols[:, i]
+
+        if refine_level >= 3:
+            # Level 3: Refine full internal Hessian (expensive!)
+            H_int_cols = self._compute_internal_hessian_columns(hessian_delta)
+            # Symmetrize and set the internal-internal block
+            H0_full[:self.n_internal, :self.n_internal] = (H_int_cols + H_int_cols.T) / 2
+
+        if refine_level == 0:
+            # No refinement: use diagonal guess for cell block
+            h0_cell = 1.0
+            H0_full[self.n_internal:, self.n_internal:] = h0_cell * np.eye(self.n_cell_dof)
+
+        # Save Hessian if requested
+        if save_hessian is not None:
+            np.save(save_hessian, H0_full)
+            logger.info("Initial Hessian saved to %s", save_hessian)
+
+        # With FD-refined Hessian (refine_level >= 1), use initialized=False
+        # to preserve the refined cell block on the first BFGS update — the
+        # uninitialized path only updates B[:ncart, :ncart] (internal block),
+        # which is appropriate since the FD-refined cell block is better than
+        # what one BFGS update would produce.
+        # Without refinement, use initialized=True so the first BFGS update
+        # covers all DOF including cell.
+        self.set_H(H0_full, initialized=(refine_level == 0))
+
+    def maybe_niggli_reduce(self, angle_threshold=30.0):
+        """Apply Niggli reduction if cell angles deviate too far from 90 deg.
+
+        When the unit cell becomes highly skewed during optimization, this
+        remaps to the most compact (Niggli-reduced) cell and resets the
+        log-deformation reference. The cell block of the Hessian is
+        transformed to the new parameterization basis via the Jacobian of
+        the log-deformation map.
+
+        Parameters
+        ----------
+        angle_threshold : float
+            Maximum deviation from 90 deg before triggering reduction.
+            Default 30 means reduction triggers when any angle < 60 or > 120.
+
+        Returns
+        -------
+        bool
+            True if reduction was applied.
+        """
+        angles = self.atoms.get_cell().angles()
+        max_deviation = max(abs(a - 90.0) for a in angles)
+        if max_deviation <= angle_threshold:
+            return False
+
+        H = self.H.B.copy()
+        n = self.n_internal
+        T_masked = _niggli_hessian_transform(
+            self.atoms, self.orig_cell, self.exp_cell_factor, self.cell_mask
+        )
+
+        # Transform cell-cell block: H_new = T^T @ H_old @ T
+        H_cell_new = T_masked.T @ H[n:, n:] @ T_masked
+        H[n:, n:] = H_cell_new
+
+        # Transform coupling blocks
+        H[:n, n:] = H[:n, n:] @ T_masked
+        H[n:, :n] = T_masked.T @ H[n:, :n]
+
+        self.orig_cell = self.atoms.get_cell().array.copy()
+        self.set_H(H, initialized=True)
+
+        # Reset cached state so next evaluation recomputes everything
+        self.curr = dict(x=None, f=None, g=None)
+        self.last = self.curr.copy()
+
+        return True
+
+    def save(self):
+        """Save current state including cell."""
+        InternalPES.save(self)
+        self.savepoint['cell'] = self.atoms.get_cell().array.copy()
+
+    def restore(self):
+        """Restore saved state including cell."""
+        InternalPES.restore(self)
+        if 'cell' in self.savepoint:
+            self.atoms.set_cell(self.savepoint['cell'], scale_atoms=False)
+
+    def refine_hessian(self, refine_level: int = 1, delta: float = 1e-5):
+        """Re-refine Hessian blocks via finite differences during optimization.
+
+        This can help recover from accumulated bad curvature in the Hessian
+        that develops during BFGS updates.
+
+        Parameters
+        ----------
+        refine_level : int
+            Level of refinement (1=cell, 2=cell+TRIC, 3=full internal).
+        delta : float
+            Finite difference step size.
+        """
+        if refine_level < 1:
+            return
+
+        # Get current Hessian
+        H = self.H.asarray()
+
+        if refine_level >= 1:
+            # Level 1: Refine cell-related blocks
+            H_cell_cols = self._compute_cell_hessian_columns(delta)
+            # Set internal-cell coupling (and its transpose for symmetry)
+            H[:self.n_internal, self.n_internal:] = H_cell_cols[:self.n_internal, :]
+            H[self.n_internal:, :self.n_internal] = H_cell_cols[:self.n_internal, :].T
+            # Set cell-cell block with explicit symmetrization
+            H_cell_cell = H_cell_cols[self.n_internal:, :]
+            H[self.n_internal:, self.n_internal:] = (H_cell_cell + H_cell_cell.T) / 2
+
+        if refine_level >= 2:
+            # Level 2: Also refine translation and rotation blocks
+            H_tric_cols = self._compute_tric_hessian_columns(delta)
+            tric_indices = self._get_tric_indices()
+            for i, idx in enumerate(tric_indices):
+                H[:, idx] = H_tric_cols[:, i]
+                H[idx, :] = H_tric_cols[:, i]
+
+        if refine_level >= 3:
+            # Level 3: Refine full internal Hessian (expensive!)
+            H_int_cols = self._compute_internal_hessian_columns(delta)
+            # Symmetrize and set the internal-internal block
+            H[:self.n_internal, :self.n_internal] = (H_int_cols + H_int_cols.T) / 2
+
+        # Update the Hessian (preserves eigenvalue tracking, etc.)
+        self.set_H(H, initialized=True)
+        logger.info("Hessian re-refined at level %d", refine_level)
+
+    def _compute_cell_hessian_columns(self, delta: float) -> np.ndarray:
+        """Compute Hessian columns for cell DOF via finite differences.
+
+        This computes d(gradient)/d(cell_param) for all cell parameters,
+        giving us both the internal-cell coupling block and the cell-cell block.
+
+        Parameters
+        ----------
+        delta : float
+            Finite difference step size.
+
+        Returns
+        -------
+        H_cols : ndarray
+            Array of shape (dim, n_cell_dof) containing Hessian columns.
+        """
+        H_cols = np.zeros((self.dim, self.n_cell_dof))
+
+        # Save current state
+        x0 = self.get_x()
+        cell0 = self.atoms.get_cell().array.copy()
+        pos0 = self.atoms.positions.copy()
+
+        n_evals = 2 * self.n_cell_dof
+        logger.info("Refining initial Hessian: 0/%d force calls", n_evals)
+
+        for i in range(self.n_cell_dof):
+            # Restore state before each FD probe to ensure path-independence
+            self.atoms.positions = pos0.copy()
+            self.atoms.set_cell(cell0, scale_atoms=False)
+
+            # Displace cell parameter +delta
+            x_plus = x0.copy()
+            x_plus[self.n_internal + i] += delta
+            self.set_x(x_plus)
+            _, g_plus = self.eval()
+            logger.info("Refining initial Hessian: %d/%d force calls", 2*i + 1, n_evals)
+
+            # Restore before -delta
+            self.atoms.positions = pos0.copy()
+            self.atoms.set_cell(cell0, scale_atoms=False)
+
+            # Displace cell parameter -delta
+            x_minus = x0.copy()
+            x_minus[self.n_internal + i] -= delta
+            self.set_x(x_minus)
+            _, g_minus = self.eval()
+            logger.info("Refining initial Hessian: %d/%d force calls", 2*i + 2, n_evals)
+
+            # Central difference
+            H_cols[:, i] = (g_plus - g_minus) / (2 * delta)
+
+
+        # Restore original state
+        self.atoms.positions = pos0
+        self.atoms.set_cell(cell0, scale_atoms=False)
+        # Clear cached values to force recomputation
+        self.curr['x'] = None
+        self.curr['f'] = None
+        self.curr['g'] = None
+
+        return H_cols
+
+    def _get_tric_indices(self) -> np.ndarray:
+        """Get indices of translation and rotation coordinates in internal space."""
+        n_trans = len(self.int.internals['translations'])
+        n_bonds = len(self.int.internals['bonds'])
+        n_angles = len(self.int.internals['angles'])
+        n_dihedrals = len(self.int.internals['dihedrals'])
+        n_rot = len(self.int.internals['rotations'])
+
+        # Internal coord order: translations, bonds, angles, dihedrals, other, rotations
+        trans_indices = list(range(n_trans))
+        rot_start = n_trans + n_bonds + n_angles + n_dihedrals + len(self.int.internals['other'])
+        rot_indices = list(range(rot_start, rot_start + n_rot))
+
+        return np.array(trans_indices + rot_indices)
+
+    def _compute_tric_hessian_columns(self, delta: float) -> np.ndarray:
+        """Compute Hessian columns for translation/rotation DOF via finite differences.
+
+        This refines the coupling between TRICs and all other coordinates,
+        which is important for molecular crystals where fragment motions are coupled.
+
+        Parameters
+        ----------
+        delta : float
+            Finite difference step size.
+
+        Returns
+        -------
+        H_cols : ndarray
+            Array of shape (dim, n_tric) containing Hessian columns.
+        """
+        tric_indices = self._get_tric_indices()
+        n_tric = len(tric_indices)
+        H_cols = np.zeros((self.dim, n_tric))
+
+        # Save current state
+        x0 = self.get_x()
+        cell0 = self.atoms.get_cell().array.copy()
+        pos0 = self.atoms.positions.copy()
+
+        n_evals = 2 * n_tric
+        logger.info("Refining TRIC Hessian: 0/%d force calls", n_evals)
+
+        for i, idx in enumerate(tric_indices):
+            # Displace TRIC parameter +delta
+            self.atoms.positions = pos0.copy()
+            self.atoms.set_cell(cell0, scale_atoms=False)
+            x_plus = x0.copy()
+            x_plus[idx] += delta
+            self.set_x(x_plus)
+            _, g_plus = self.eval()
+            logger.info("Refining TRIC Hessian: %d/%d force calls", 2*i + 1, n_evals)
+
+            # Displace TRIC parameter -delta
+            self.atoms.positions = pos0.copy()
+            self.atoms.set_cell(cell0, scale_atoms=False)
+            x_minus = x0.copy()
+            x_minus[idx] -= delta
+            self.set_x(x_minus)
+            _, g_minus = self.eval()
+            logger.info("Refining TRIC Hessian: %d/%d force calls", 2*i + 2, n_evals)
+
+            # Central difference
+            H_cols[:, i] = (g_plus - g_minus) / (2 * delta)
+
+
+        # Restore original state
+        self.atoms.positions = pos0
+        self.atoms.set_cell(cell0, scale_atoms=False)
+        # Clear cached values to force recomputation
+        self.curr['x'] = None
+        self.curr['f'] = None
+        self.curr['g'] = None
+
+        return H_cols
+
+    def _compute_internal_hessian_columns(self, delta: float) -> np.ndarray:
+        """Compute full internal-internal Hessian block via finite differences.
+
+        This is expensive: requires 2 * n_internal force evaluations.
+        Only use when a highly accurate initial Hessian is needed.
+
+        Parameters
+        ----------
+        delta : float
+            Finite difference step size.
+
+        Returns
+        -------
+        H_int : ndarray
+            Array of shape (n_internal, n_internal) containing the internal Hessian.
+        """
+        H_int = np.zeros((self.n_internal, self.n_internal))
+
+        # Save current state
+        x0 = self.get_x()
+        cell0 = self.atoms.get_cell().array.copy()
+        pos0 = self.atoms.positions.copy()
+
+        n_evals = 2 * self.n_internal
+        logger.info("Refining internal Hessian: 0/%d force calls", n_evals)
+
+        for i in range(self.n_internal):
+            # Displace internal coordinate +delta
+            self.atoms.positions = pos0.copy()
+            self.atoms.set_cell(cell0, scale_atoms=False)
+            x_plus = x0.copy()
+            x_plus[i] += delta
+            self.set_x(x_plus)
+            _, g_plus = self.eval()
+
+            # Displace internal coordinate -delta
+            self.atoms.positions = pos0.copy()
+            self.atoms.set_cell(cell0, scale_atoms=False)
+            x_minus = x0.copy()
+            x_minus[i] -= delta
+            self.set_x(x_minus)
+            _, g_minus = self.eval()
+
+            # Central difference - only internal part
+            H_int[:, i] = (g_plus[:self.n_internal] - g_minus[:self.n_internal]) / (2 * delta)
+
+            # Progress update every 10 columns or at the end
+            if (i + 1) % 10 == 0 or i == self.n_internal - 1:
+                logger.info("Refining internal Hessian: %d/%d force calls", 2*(i+1), n_evals)
+
+
+        # Restore original state
+        self.atoms.positions = pos0
+        self.atoms.set_cell(cell0, scale_atoms=False)
+        # Clear cached values to force recomputation
+        self.curr['x'] = None
+        self.curr['f'] = None
+        self.curr['g'] = None
+
+        return H_int
+
+    def get_x(self) -> np.ndarray:
+        """Return combined internal coordinates + cell parameters.
+
+        During initialization (_initializing=True), returns only internal coords
+        to be compatible with parent class initialization.
+        """
+        q = self.int.calc()  # Internal coordinates
+
+        # During parent initialization, return only internal coords
+        if self._initializing:
+            return q
+
+        cell_params = self._masked_cell_params()  # Cell DOF
+        x = np.concatenate([q, cell_params])
+
+        # Unwrap dihedrals to prevent ±π branch cut jumps
+        if self.curr['x'] is not None:
+            dih_start = (self.int.ntrans + self.int.nbonds
+                         + self.int.nangles)
+            dih_end = dih_start + self.int.ndihedrals
+            if dih_end > dih_start:
+                dx = x[dih_start:dih_end] - self.curr['x'][dih_start:dih_end]
+                x[dih_start:dih_end] = (
+                    self.curr['x'][dih_start:dih_end]
+                    + (dx + np.pi) % (2 * np.pi) - np.pi
+                )
+        return x
+
+    def _get_deformation_gradient(self) -> np.ndarray:
+        """Get current deformation gradient F = cell @ inv(orig_cell)."""
+        return self.atoms.get_cell().array @ np.linalg.inv(self.orig_cell)
+
+    def _get_log_deform(self) -> np.ndarray:
+        """Get log of deformation gradient, scaled by exp_cell_factor."""
+        F = self._get_deformation_gradient()
+        return _logm_3x3(F) * self.exp_cell_factor
+
+    def _set_cell_from_log_deform(self, log_deform_scaled: np.ndarray) -> None:
+        """Set cell from scaled log-deformation gradient.
+
+        When rigid_fragments is False, scales atomic positions with cell
+        (fixed fractional coords), matching the virial stress definition.
+
+        When rigid_fragments is True, keeps Cartesian positions fixed here.
+        The rigid fragment CoM translation in set_x() then moves each fragment
+        to maintain its fractional CoM position while preserving intramolecular
+        geometry.
+        """
+        log_deform = log_deform_scaled / self.exp_cell_factor
+        F = expm(log_deform.real)
+        new_cell = F @ self.orig_cell
+        self.atoms.set_cell(new_cell, scale_atoms=not self.rigid_fragments)
+
+    def _masked_cell_params(self) -> np.ndarray:
+        """Get cell parameters as flat array (only free DOF)."""
+        log_deform = self._get_log_deform()
+        return log_deform[self.cell_mask]
+
+    def _set_masked_cell_params(self, params: np.ndarray) -> None:
+        """Set cell from flat array of free DOF."""
+        log_deform = self._get_log_deform()
+        log_deform[self.cell_mask] = params
+        self._set_cell_from_log_deform(log_deform)
+
+    @staticmethod
+    def _extract_fragment_groups(internals):
+        """Extract fragment atom groups for rigid-body operations.
+
+        Uses the original fragment groups stored during find_all_bonds,
+        which contain all real atoms. Translation coordinates get
+        corrupted by add_dummy_to_internals (drops the last real atom),
+        so we avoid using those. Dummy indices are found via dinds.
+
+        Returns
+        -------
+        list of ndarray
+            Each element is an array of real atom indices for one fragment.
+        list of ndarray
+            Each element is an array of dummy atom indices for the same fragment.
+        """
+        if internals.fragment_atom_groups is not None:
+            groups = internals.fragment_atom_groups
+        else:
+            natoms = internals.natoms
+            groups = []
+            for trans in internals.internals.get('translations', []):
+                if trans.kwargs['dim'] == 0:
+                    indices = np.array(trans.indices)
+                    groups.append(indices[indices < natoms])
+
+        dummy_groups = []
+        for group in groups:
+            dummies = []
+            for atom_idx in group:
+                didx = internals.dinds[atom_idx]
+                if didx >= 0:
+                    dummies.append(didx)
+            dummy_groups.append(np.array(dummies, dtype=np.int32))
+
+        return groups, dummy_groups
+
+    def _compute_delta_r(self):
+        """Compute positions relative to fragment center of mass.
+
+        Returns Δr = r - r_CoM_expanded, where each atom's position is
+        relative to its fragment's geometric center. Uses geometric center
+        (unweighted mean) for consistency with how TRICs define translations.
+
+        Returns
+        -------
+        delta_r : ndarray, shape (n_atoms, 3)
+        """
+        positions = self.atoms.get_positions()
+        delta_r = positions.copy()
+        for group in self.fragment_groups:
+            if len(group) > 0:
+                com = positions[group].mean(axis=0)
+                delta_r[group] -= com
+        return delta_r
+
+    def set_x(self, target: np.ndarray):
+        """Set internal coordinates and cell parameters.
+
+        This is more complex than InternalPES.set_x because:
+        1. We first update the cell (which changes internal coord values)
+        2. Then apply only the internal coordinate *step* (dq) on top
+
+        The cell change moves atoms according to the mode:
+        - rigid_fragments=True: scale_atoms=False + CoM translation
+          (preserves intramolecular geometry)
+        - rigid_fragments=False: scale_atoms=True
+          (atoms scale with cell, changing bonds/angles)
+
+        In both cases, the internal coord solver only applies the dq
+        displacement requested by the optimizer, NOT the full q_target.
+        This ensures the gradient is consistent with the actual displacement.
+
+        Returns
+        -------
+        dx_initial, dx_final, g_par : tuple of np.ndarray
+            Displacement information for Hessian update.
+        """
+        x0 = self.get_x()
+        dx_initial = target - x0
+
+        # Split target into internal and cell parts
+        # dq is the internal coordinate step the optimizer requested
+        q0 = x0[:self.n_internal]
+        dq = target[:self.n_internal] - q0
+        cell_target = target[self.n_internal:]
+
+        # Get initial cell params
+        cell_params0 = self._masked_cell_params()
+
+        # Save state before cell change for rigid fragment mode
+        if self.rigid_fragments:
+            pos_before = self.atoms.get_positions().copy()
+            cell_before = self.atoms.get_cell().array.copy()
+
+        # Update cell (scales atoms if rigid_fragments=False)
+        self._set_masked_cell_params(cell_target)
+
+        # Rigid fragment mode: translate fragment CoMs to maintain
+        # fractional positions, and rotate fragments by R from polar
+        # decomposition of the incremental deformation gradient.
+        if self.rigid_fragments:
+            cell_after = self.atoms.get_cell().array
+            cell_before_inv = np.linalg.inv(cell_before)
+            F_inc = cell_after @ cell_before_inv
+            R_inc, _ = polar(F_inc)
+            for group, dgroup in zip(self.fragment_groups,
+                                     self.fragment_dummy_groups):
+                com_old = pos_before[group].mean(axis=0)
+                # Convert old CoM to fractional, then to new Cartesian
+                com_frac = com_old @ cell_before_inv
+                com_new = com_frac @ cell_after
+                # Rotate relative positions by R (row-vector: r_new = r @ R^T)
+                delta_r = pos_before[group] - com_old
+                self.atoms.positions[group] = com_new + delta_r @ R_inc.T
+                # Move dummy atoms with the same transformation
+                if len(dgroup) > 0:
+                    didx = dgroup - self.int.natoms  # Convert to dummies index
+                    delta_d = self.dummies.positions[didx] - com_old
+                    self.dummies.positions[didx] = com_new + delta_d @ R_inc.T
+
+        # Read back internal coords AFTER the cell change moved atoms.
+        # The solver targets q_after_cell + dq, not the raw q_target.
+        # This ensures we don't undo the atom motion from the cell change.
+        q_after_cell = self.int.calc()
+        q_target = q_after_cell + dq
+
+        # If there are no internal coordinates, we're done
+        if self.n_internal == 0:
+            # Cell-only case: dx_final equals the cell displacement
+            dx_cell = cell_target - cell_params0
+            dx_final = dx_cell.copy()
+            # Return actual cell gradient at starting position for proper Hessian update
+            # (dg_actual = get_g() - g_par needs g_par to be the old gradient)
+            g_old = self.curr.get('g', None)
+            if g_old is not None:
+                g_final = g_old[-self.n_cell_dof:].copy()
+            else:
+                g_final = np.zeros(self.n_cell_dof)
+            return dx_initial, dx_final, g_final
+
+        # Now update atomic positions to match internal coordinate target
+        res = self._set_x_ode_internal(q_target)
+
+        # Project onto constraint manifold (decoupled from trust radius).
+        # Only when ODE succeeded — the InternalPES.set_x fallback below
+        # runs its own projection internally.
+        proj_moved = False
+        if res is not None:
+            q_after_ode = self.int.calc().copy()
+            proj_moved = self._project_to_constraints()
+
+        # Get old cell gradient for parallel transport (needed for correct
+        # BFGS secant condition on the cell block of the Hessian)
+        g_old = self.curr.get('g', None)
+        if g_old is not None:
+            g_old_cell = g_old[self.n_internal:].copy()
+        else:
+            g_old_cell = np.zeros(self.n_cell_dof)
+
+        if res is None:
+            # Fallback: just do parent set_x ignoring cell
+            dx_int, _, g_int = InternalPES.set_x(self, q_target)
+            dx_final = np.concatenate([dx_int, cell_target - cell_params0])
+            g_final = np.concatenate([g_int, g_old_cell])
+        else:
+            dx_int_initial, dx_int_final, g_int = res
+            # Combine the ODE-tangent step with the projection's IC delta
+            # so BFGS sees a coherent secant. When the projection didn't
+            # fire this is a pure passthrough of dx_int_final.
+            dx_int_realized = self._add_proj_delta(dx_int_final, q_after_ode,
+                                                    proj_moved)
+            dx_final = np.concatenate([dx_int_realized, cell_target - cell_params0])
+            g_final = np.concatenate([g_int, g_old_cell])
+
+        return dx_initial, dx_final, g_final
+
+    def _set_x_ode_internal(self, q_target: np.ndarray, old_g_cart=None):
+        """ODE-based stepper for internal coords only (cell already updated)."""
+        x0 = self.int.calc()
+        dx = q_target - x0
+        t0 = 0.
+        Binv = self._get_Binv()
+        self._ode_Binv = Binv
+
+        if 'g' in self.curr and self.curr['g'] is not None:
+            g_cart_for_ode = Binv @ self.curr['g'][:self.n_internal]
+        else:
+            g_cart_for_ode = np.zeros(3 * (len(self.atoms) + len(self.dummies)))
+
+        y0 = np.hstack((
+            self.apos.ravel(),
+            self.dpos.ravel(),
+            Binv @ dx,
+            g_cart_for_ode,
+        ))
+        ode = LSODA(self._q_ode, t0, y0, t_bound=1., atol=1e-6)
+
+        while ode.status == 'running':
+            ode.step()
+            y = ode.y
+            t0 = ode.t
+            self.bad_int = self.int.check_for_bad_internals()
+            if self.bad_int is not None:
+                break
+            if ode.nfev > 1000:
+                raise RuntimeError("Geometry update ODE is taking too long!")
+
+        if ode.status == 'failed':
+            raise RuntimeError("Geometry update ODE failed to converge!")
+
+        nxa = 3 * len(self.atoms)
+        nxd = 3 * len(self.dummies)
+        y = y.reshape((3, nxa + nxd))
+        self.atoms.positions = y[0, :nxa].reshape((-1, 3))
+        self.dummies.positions = y[0, nxa:].reshape((-1, 3))
+        B = self.int.jacobian()
+        dx_final = t0 * B @ y[1]
+        g_final = B @ y[2]
+        dx_initial = t0 * dx
+        return dx_initial, dx_final, g_final
+
+    def eval(self) -> tuple:
+        """Evaluate energy and combined gradient (internal + cell)."""
+        self.neval += 1
+        f = self.atoms.get_potential_energy()
+
+        # Add pressure contribution: H = E + P*V
+        if self.scalar_pressure != 0.0:
+            f += self.scalar_pressure * self.atoms.get_volume()
+
+        # Atomic forces -> internal coordinate gradient
+        forces = self.atoms.get_forces()
+        g_cart = -forces.ravel()
+        Binv = self._get_Binv()
+        g_internal = g_cart @ Binv[:len(g_cart)]
+
+        # Stress tensor -> cell gradient
+        stress = self.atoms.get_stress()  # 6-component Voigt, eV/Å³
+        g_cell = self._stress_to_cell_gradient(stress, forces=forces)
+
+        self.write_traj()
+        return f, np.concatenate([g_internal, g_cell])
+
+    def _stress_to_cell_gradient(self, stress_voigt: np.ndarray, forces: np.ndarray = None) -> np.ndarray:
+        """Convert stress tensor to gradient w.r.t. log-deformation cell parameters.
+
+        Uses the Frechet derivative of the matrix exponential to correctly
+        transform dE/dF into dE/dU = dE/d(log F).
+
+        The virial stress V*σ relates to dE/dC via (ASE row-vector convention):
+            V*σ = dE/dC^T @ C - f^T @ r
+
+        For different atom-motion modes (where Δr = r - r_CoM_expanded):
+            default:            dE/dC = C^{-T} @ V*σ                    @ C₀^T
+            rigid_fragments:    dE/dC = C^{-T} @ (V*σ + Δr^T @ f)       @ C₀^T
+
+        Parameters
+        ----------
+        stress_voigt : ndarray
+            6-component Voigt stress tensor.
+        forces : ndarray, optional
+            Atomic forces, shape (n_atoms, 3). Required when rigid_fragments=True.
+        """
+        volume = self.atoms.get_volume()
+        stress_3x3 = voigt_6_to_full_3x3_stress(stress_voigt)
+
+        # Add external pressure contribution
+        if self.scalar_pressure != 0.0:
+            stress_3x3 += self.scalar_pressure * np.eye(3)
+
+        # The virial V*σ is the base term
+        virial = volume * stress_3x3
+
+        if self.rigid_fragments and forces is not None:
+            # Rigid fragment mode: use Δr^T @ f correction
+            # Δr = positions relative to fragment CoM
+            delta_r = self._compute_delta_r()
+            virial_corrected = virial + delta_r.T @ forces
+        else:
+            virial_corrected = virial
+
+        # dE/dC = C^{-T} @ virial_corrected, then dE/dF = dE/dC @ C₀^T
+        C = self.atoms.get_cell().array
+        C_inv_T = np.linalg.inv(C.T)
+        dEdF = C_inv_T @ virial_corrected @ self.orig_cell.T
+
+        if self.rigid_fragments and forces is not None:
+            # Rotation correction: fragments rotate by R from polar decomposition
+            # of F, so dE/dF gets an additional term from ∂R/∂F.
+            # rot_correction_mn = -Σ_{kl} (∂R_kl/∂F_mn) * [f^T @ Δr⁰]_kl
+            # where Δr⁰ = Δr @ R (back-rotated to reference frame)
+            F = self._get_deformation_gradient()
+            R_polar, _ = polar(F)
+            delta_r_ref = delta_r @ R_polar
+            M = forces.T @ delta_r_ref
+
+            eps = 1e-7
+            rot_correction = np.zeros((3, 3))
+            for m in range(3):
+                for n in range(3):
+                    F_pert = F.copy()
+                    F_pert[m, n] += eps
+                    R_pert, _ = polar(F_pert)
+                    dR = (R_pert - R_polar) / eps
+                    rot_correction[m, n] = -np.sum(dR * M)
+            dEdF += rot_correction
+
+        # Convert dE/dF to dE/dU via Frechet derivative of expm
+        F = self._get_deformation_gradient()
+        U = _logm_3x3(F)
+        g_cell_3x3 = _expm_frechet_3x3_contracted(U, dEdF)
+
+        # Apply cell mask and scale
+        g_cell_3x3 = g_cell_3x3 * self.cell_mask
+        g_cell_3x3 = g_cell_3x3 / self.exp_cell_factor
+
+        return g_cell_3x3[self.cell_mask]
+
+    def _calc_basis(self, internal=None, cons=None):
+        """Calculate basis including cell DOF.
+
+        The cell DOF are treated as unconstrained additional coordinates.
+        """
+        # Refine paths pass custom internal/cons; fall back to the parent's
+        # full path (bypasses parent's cache too) and return without caching
+        # on this side.
+        if internal is not None or cons is not None:
+            result = InternalPES._calc_basis(self, internal=internal, cons=cons)
+            return self._extend_basis_with_cell(result)
+
+        state_hash = self._state_hash()
+        cached = self._cell_basis_cache.get(state_hash)
+        if cached is not None:
+            return cached
+
+        # Compute the internal-only basis directly (bypass parent's cache —
+        # we cache the cell-extended form here instead, so the parent cache
+        # would just hold a redundant unpadded copy).
+        result = self._compute_basis_int()
+        out = self._extend_basis_with_cell(result)
+        self._cell_basis_cache.put(state_hash, out)
+        return out
+
+    def _extend_basis_with_cell(self, basis_int):
+        """Pad an internal-only basis with cell DOF (identity in Unred/Ufree)."""
+        drdx_int, Ucons_int, Unred_int, Ufree_int = basis_int
+        n_int = drdx_int.shape[1]
+        n_total = n_int + self.n_cell_dof
+
+        # Cell DOF are not constrained, so they're all in Ufree
+        drdx = np.zeros((drdx_int.shape[0], n_total))
+        drdx[:, :n_int] = drdx_int
+
+        Ucons = np.zeros((n_total, Ucons_int.shape[1]))
+        Ucons[:n_int, :] = Ucons_int
+
+        Unred = self._pad_with_cell_identity(Unred_int)
+
+        # When there are no constraints, _compute_basis_int returns
+        # ``Ufree is Unred`` (same object). Share the extended array too —
+        # avoids a second ~3 MB slice copy on every call.
+        if Ufree_int is Unred_int:
+            Ufree = Unred
+        else:
+            Ufree = self._pad_with_cell_identity(Ufree_int)
+
+        return drdx, Ucons, Unred, Ufree
+
+    def _pad_with_cell_identity(self, M_int):
+        """Build (n_int + n_cell, M_int.shape[1] + n_cell) with M_int and an
+        identity block in the cell-DOF corner. Uses np.empty and explicit
+        zero strips to skip the bulk np.zeros memset for the n_int block
+        that's about to be overwritten anyway."""
+        n_int, n_cols = M_int.shape
+        n_cell = self.n_cell_dof
+        out = np.empty((n_int + n_cell, n_cols + n_cell))
+        out[:n_int, :n_cols] = M_int
+        out[:n_int, n_cols:] = 0
+        out[n_int:, :n_cols] = 0
+        out[n_int:, n_cols:] = np.eye(n_cell)
+        return out
+
+    def converged(self, fmax: float, smax: float = None, cmax: float = 1e-5):
+        """Check convergence of forces and stress.
+
+        Parameters
+        ----------
+        fmax : float
+            Maximum force tolerance (eV/Å).
+        smax : float, optional
+            Maximum stress tolerance. If None, uses fmax.
+        cmax : float, optional
+            Constraint residual tolerance.
+
+        Returns
+        -------
+        conv : bool
+            True if converged.
+        fmax_actual : float
+            Maximum force.
+        cmax_actual : float
+            Constraint residual norm.
+        smax_actual : float
+            Maximum stress gradient.
+        """
+        if smax is None:
+            smax = fmax
+
+        # Force convergence (project out constraints).
+        # Associate as U @ (U.T @ g) — two cheap matvecs — instead of
+        # (U @ U.T) @ g which materializes a (n_int, n_int) intermediate.
+        g = self.get_g()
+        g_internal = g[:self.n_internal]
+        Ufree_int = self.curr['Ufree'][:self.n_internal, :self.curr['Ufree'].shape[1] - self.n_cell_dof]
+        g_proj = Ufree_int @ (Ufree_int.T @ g_internal)
+
+        # Convert to Cartesian for force norm
+        B = self.int.jacobian()
+        g_cart = (g_proj @ B).reshape((-1, 3))
+        fmax_actual = np.linalg.norm(g_cart, axis=1).max()
+
+        # Stress convergence
+        g_cell = g[self.n_internal:]
+        smax_actual = np.abs(g_cell).max() if len(g_cell) > 0 else 0.0
+
+        # Constraint residual
+        cmax_actual = np.linalg.norm(self.get_res())
+
+        conv = (fmax_actual < fmax) and (smax_actual < smax) and (cmax_actual < cmax)
+        return conv, fmax_actual, cmax_actual, smax_actual
+
+    def get_projected_forces(self) -> np.ndarray:
+        """Returns Nx3 array of atomic forces orthogonal to constraints."""
+        g = self.get_g()
+        g_internal = g[:self.n_internal]
+        Ufree = self.get_Ufree()
+        Ufree_int = Ufree[:self.n_internal, :]
+        B = self.int.jacobian()
+        return -(Ufree_int @ (Ufree_int.T @ g_internal) @ B).reshape((-1, 3))
+
+    def get_drdx(self):
+        """Get constraint Jacobian extended for cell DOF.
+
+        The constraint Jacobian from the parent class only has columns for
+        internal coordinates. We extend it with zero columns for cell DOF
+        since there are no constraints on the cell.
+        """
+        # Get internal constraint Jacobian from parent
+        drdx_int = InternalPES.get_drdx(self)
+
+        # Extend with zeros for cell DOF
+        n_cons = drdx_int.shape[0]
+        drdx = np.zeros((n_cons, self.dim))
+        drdx[:, :self.n_internal] = drdx_int
+
+        return drdx
+
+    def get_Hc(self):
+        """Get constraint Hessian extended for cell DOF.
+
+        The constraint Hessian from InternalPES has shape (n_internal, n_internal).
+        We extend it with zeros to (dim, dim) since there are no constraints
+        on cell DOF.
+        """
+        state_hash = self._state_hash()
+        cached = self._Hc_cell_cache.get(state_hash)
+        if cached is not None:
+            return cached
+
+        # Compute the internal-only Hc directly (bypass parent's _Hc_cache —
+        # we cache the cell-extended form here instead, so the parent cache
+        # would just hold a redundant unpadded copy).
+        Hc_int = self._compute_Hc_int()
+
+        # Extend to full dimension
+        Hc = np.zeros((self.dim, self.dim))
+        n_int = self.n_internal
+        if Hc_int.size > 0:
+            Hc[:n_int, :n_int] = Hc_int
+
+        self._Hc_cell_cache.put(state_hash, Hc)
+        return Hc
+
+
+class CellCartesianPES(PES):
+    """Cartesian PES with unit cell optimization.
+
+    This class extends PES to simultaneously optimize both atomic Cartesian
+    positions and the unit cell parameters.
+
+    The cell is parameterized using the log of the deformation gradient:
+        F = cell @ inv(orig_cell)
+        cell_params = _logm_3x3(F) * exp_cell_factor
+
+    This parameterization ensures that:
+    1. The identity corresponds to zero cell parameters
+    2. Small deformations are approximately linear in the parameters
+    3. Large deformations are handled smoothly
+
+    Parameters
+    ----------
+    atoms : Atoms
+        ASE Atoms object with periodic boundary conditions.
+    exp_cell_factor : float, optional
+        Scaling factor for cell parameterization. Default is number of atoms.
+    cell_mask : ndarray, optional
+        Boolean mask of shape (3, 3) indicating which cell DOF are free.
+        Default is all True (full cell optimization).
+    scalar_pressure : float, optional
+        External pressure in eV/Å³. Default is 0.
+    refine_initial_hessian : bool or int, optional
+        Level of Hessian refinement via finite differences:
+        - False or 0: No refinement (default)
+        - True or 1: Refine cell-related blocks only (2 * n_cell_dof force calls)
+        Note: Level 2 (TRICs) is not applicable for Cartesian coordinates.
+    hessian_delta : float, optional
+        Finite difference step size for Hessian refinement. Default is 1e-5.
+    save_hessian : str, optional
+        Path to save the initial Hessian as .npy file for analysis.
+    """
+
+    def __init__(
+        self,
+        atoms: Atoms,
+        *args,
+        exp_cell_factor: float = None,
+        cell_mask: np.ndarray = None,
+        scalar_pressure: float = 0.0,
+        refine_initial_hessian: Union[bool, int] = False,
+        hessian_delta: float = 1e-5,
+        save_hessian: str = None,
+        H0: np.ndarray = None,
+        **kwargs
+    ):
+        """Initialize CellCartesianPES.
+
+        Parameters
+        ----------
+        refine_initial_hessian : bool or int
+            Level of Hessian refinement via finite differences:
+            - False or 0: No refinement (default)
+            - True or 1: Refine cell-related blocks only
+            Note: Level 2 (TRICs) is not applicable for Cartesian coordinates.
+        save_hessian : str, optional
+            Path to save the initial Hessian as .npy file for analysis.
+        """
+        # Store original cell as reference before any optimization
+        self.orig_cell = atoms.get_cell().array.copy()
+
+        # Cell parameterization scaling (like ASE's FrechetCellFilter)
+        if exp_cell_factor is None:
+            exp_cell_factor = float(len(atoms))
+        self.exp_cell_factor = exp_cell_factor
+
+        # Cell mask: which of the 9 cell matrix elements are free
+        if cell_mask is None:
+            cell_mask = np.ones((3, 3), dtype=bool)
+        self.cell_mask = np.asarray(cell_mask, dtype=bool).reshape((3, 3))
+        self.n_cell_dof = int(self.cell_mask.sum())
+
+        # External pressure
+        self.scalar_pressure = scalar_pressure
+
+        # Flag to control get_x behavior during parent initialization
+        self._initializing = True
+
+        # Initialize parent class - PES uses 3*natoms as dimension
+        PES.__init__(self, atoms, *args, H0=H0, **kwargs)
+
+        # Store Cartesian dimension (set by parent)
+        self.n_cart = self.dim  # 3 * natoms
+
+        # Update dimension to include cell DOF
+        self.dim = self.n_cart + self.n_cell_dof
+
+        # Done initializing - now get_x returns full vector
+        self._initializing = False
+
+        # Create proper Hessian with correct dimensions
+        # Use block-diagonal structure: Cartesian Hessian + cell Hessian
+        H_old = self.H.B if self.H is not None and self.H.B is not None else None
+
+        H0_full = np.zeros((self.dim, self.dim))
+        if H_old is not None:
+            H0_full[:self.n_cart, :self.n_cart] = H_old
+        else:
+            # Default: 70 eV/Å² is reasonable for stiff materials
+            H0_full[:self.n_cart, :self.n_cart] = 70.0 * np.eye(self.n_cart)
+
+        # Convert bool to int for refinement level
+        if refine_initial_hessian is True:
+            refine_level = 1
+        elif refine_initial_hessian is False:
+            refine_level = 0
+        else:
+            refine_level = int(refine_initial_hessian)
+
+        if refine_level >= 1:
+            # Level 1: Refine cell-related blocks
+            H_cell_cols = self._compute_cell_hessian_columns(hessian_delta)
+            # Set Cartesian-cell coupling (and its transpose for symmetry)
+            H0_full[:self.n_cart, self.n_cart:] = H_cell_cols[:self.n_cart, :]
+            H0_full[self.n_cart:, :self.n_cart] = H_cell_cols[:self.n_cart, :].T
+            # Set cell-cell block with explicit symmetrization
+            H_cell_cell = H_cell_cols[self.n_cart:, :]
+            H0_full[self.n_cart:, self.n_cart:] = (H_cell_cell + H_cell_cell.T) / 2
+
+        if refine_level == 0:
+            # No refinement: use diagonal guess for cell block
+            h0_cell = 1.0
+            H0_full[self.n_cart:, self.n_cart:] = h0_cell * np.eye(self.n_cell_dof)
+
+        # Save Hessian if requested
+        if save_hessian is not None:
+            np.save(save_hessian, H0_full)
+            logger.info("Initial Hessian saved to %s", save_hessian)
+
+        self.set_H(H0_full, initialized=(refine_level == 0))
+
+    def maybe_niggli_reduce(self, angle_threshold=30.0):
+        """Apply Niggli reduction if cell angles deviate too far from 90 deg.
+
+        When the unit cell becomes highly skewed during optimization, this
+        remaps to the most compact (Niggli-reduced) cell and resets the
+        log-deformation reference. The cell block of the Hessian is
+        transformed to the new parameterization basis via the Jacobian of
+        the log-deformation map.
+
+        Parameters
+        ----------
+        angle_threshold : float
+            Maximum deviation from 90 deg before triggering reduction.
+            Default 30 means reduction triggers when any angle < 60 or > 120.
+
+        Returns
+        -------
+        bool
+            True if reduction was applied.
+        """
+        angles = self.atoms.get_cell().angles()
+        max_deviation = max(abs(a - 90.0) for a in angles)
+        if max_deviation <= angle_threshold:
+            return False
+
+        H = self.H.B.copy()
+        n = self.n_cart
+        T_masked = _niggli_hessian_transform(
+            self.atoms, self.orig_cell, self.exp_cell_factor, self.cell_mask
+        )
+
+        # Transform cell-cell block: H_new = T^T @ H_old @ T
+        H_cell_new = T_masked.T @ H[n:, n:] @ T_masked
+        H[n:, n:] = H_cell_new
+
+        # Transform coupling blocks
+        H[:n, n:] = H[:n, n:] @ T_masked
+        H[n:, :n] = T_masked.T @ H[n:, :n]
+
+        self.orig_cell = self.atoms.get_cell().array.copy()
+        self.set_H(H, initialized=True)
+
+        # Reset cached state so next evaluation recomputes everything
+        self.curr = dict(x=None, f=None, g=None)
+        self.last = self.curr.copy()
+
+        return True
+
+    def save(self):
+        """Save current state including cell."""
+        PES.save(self)
+        self.savepoint['cell'] = self.atoms.get_cell().array.copy()
+
+    def restore(self):
+        """Restore saved state including cell."""
+        PES.restore(self)
+        if 'cell' in self.savepoint:
+            self.atoms.set_cell(self.savepoint['cell'], scale_atoms=False)
+
+    def refine_hessian(self, refine_level: int = 1, delta: float = 1e-5):
+        """Re-refine Hessian blocks via finite differences during optimization.
+
+        This can help recover from accumulated bad curvature in the Hessian
+        that develops during BFGS updates.
+
+        Parameters
+        ----------
+        refine_level : int
+            Level of refinement (only level 1 supported for Cartesian).
+        delta : float
+            Finite difference step size.
+        """
+        if refine_level < 1:
+            return
+
+        # Get current Hessian
+        H = self.H.asarray()
+
+        # Level 1: Refine cell-related blocks
+        H_cell_cols = self._compute_cell_hessian_columns(delta)
+        # Set Cartesian-cell coupling (and its transpose for symmetry)
+        H[:self.n_cart, self.n_cart:] = H_cell_cols[:self.n_cart, :]
+        H[self.n_cart:, :self.n_cart] = H_cell_cols[:self.n_cart, :].T
+        # Set cell-cell block with explicit symmetrization
+        H_cell_cell = H_cell_cols[self.n_cart:, :]
+        H[self.n_cart:, self.n_cart:] = (H_cell_cell + H_cell_cell.T) / 2
+
+        # Update the Hessian (preserves eigenvalue tracking, etc.)
+        self.set_H(H, initialized=True)
+        logger.info("Hessian re-refined at level %d", refine_level)
+
+    def _compute_cell_hessian_columns(self, delta: float) -> np.ndarray:
+        """Compute Hessian columns for cell DOF via finite differences.
+
+        This computes d(gradient)/d(cell_param) for all cell parameters,
+        giving us both the Cartesian-cell coupling block and the cell-cell block.
+
+        Parameters
+        ----------
+        delta : float
+            Finite difference step size.
+
+        Returns
+        -------
+        H_cols : ndarray
+            Array of shape (dim, n_cell_dof) containing Hessian columns.
+        """
+        H_cols = np.zeros((self.dim, self.n_cell_dof))
+
+        # Save current state
+        x0 = self.get_x()
+        cell0 = self.atoms.get_cell().array.copy()
+        pos0 = self.atoms.positions.copy()
+
+        n_evals = 2 * self.n_cell_dof
+        logger.info("Refining initial Hessian: 0/%d force calls", n_evals)
+
+        for i in range(self.n_cell_dof):
+            # Restore state before each FD probe
+            self.atoms.positions = pos0.copy()
+            self.atoms.set_cell(cell0, scale_atoms=False)
+
+            # Displace cell parameter +delta
+            x_plus = x0.copy()
+            x_plus[self.n_cart + i] += delta
+            self.set_x(x_plus)
+            _, g_plus = self.eval()
+            logger.info("Refining initial Hessian: %d/%d force calls", 2*i + 1, n_evals)
+
+            # Restore before -delta
+            self.atoms.positions = pos0.copy()
+            self.atoms.set_cell(cell0, scale_atoms=False)
+
+            # Displace cell parameter -delta
+            x_minus = x0.copy()
+            x_minus[self.n_cart + i] -= delta
+            self.set_x(x_minus)
+            _, g_minus = self.eval()
+            logger.info("Refining initial Hessian: %d/%d force calls", 2*i + 2, n_evals)
+
+            # Central difference
+            H_cols[:, i] = (g_plus - g_minus) / (2 * delta)
+
+
+        # Restore original state
+        self.atoms.positions = pos0
+        self.atoms.set_cell(cell0, scale_atoms=False)
+        # Clear cached values to force recomputation
+        self.curr['x'] = None
+        self.curr['f'] = None
+        self.curr['g'] = None
+
+        return H_cols
+
+    def get_x(self) -> np.ndarray:
+        """Return Cartesian positions + cell parameters.
+
+        During initialization (_initializing=True), returns only Cartesian coords
+        to be compatible with parent class initialization.
+        """
+        x_cart = self.apos.ravel().copy()
+
+        # During parent initialization, return only Cartesian coords
+        if self._initializing:
+            return x_cart
+
+        cell_params = self._masked_cell_params()
+        return np.concatenate([x_cart, cell_params])
+
+    def _get_deformation_gradient(self) -> np.ndarray:
+        """Get current deformation gradient F = cell @ inv(orig_cell)."""
+        return self.atoms.get_cell().array @ np.linalg.inv(self.orig_cell)
+
+    def _get_log_deform(self) -> np.ndarray:
+        """Get log of deformation gradient, scaled by exp_cell_factor."""
+        F = self._get_deformation_gradient()
+        return _logm_3x3(F) * self.exp_cell_factor
+
+    def _set_cell_from_log_deform(self, log_deform_scaled: np.ndarray) -> None:
+        """Set cell from scaled log-deformation gradient.
+
+        Does not scale atoms — in CellCartesianPES, positions are set
+        explicitly by set_x() after the cell change. The gradient formula
+        already accounts for fixed-Cartesian positions via the r^T @ f term.
+        """
+        log_deform = log_deform_scaled / self.exp_cell_factor
+        F = expm(log_deform.real)
+        new_cell = F @ self.orig_cell
+        self.atoms.set_cell(new_cell, scale_atoms=False)
+
+    def _masked_cell_params(self) -> np.ndarray:
+        """Get cell parameters as flat array (only free DOF)."""
+        log_deform = self._get_log_deform()
+        return log_deform[self.cell_mask]
+
+    def _set_masked_cell_params(self, params: np.ndarray) -> None:
+        """Set cell from flat array of free DOF."""
+        log_deform = self._get_log_deform()
+        log_deform[self.cell_mask] = params
+        self._set_cell_from_log_deform(log_deform)
+
+    def set_x(self, target: np.ndarray):
+        """Set Cartesian positions and cell parameters.
+
+        Much simpler than CellInternalPES since Cartesian positions can be
+        set directly without iterative or ODE-based solvers.
+
+        Returns
+        -------
+        dx_initial, dx_final, g_par : tuple of np.ndarray
+            Displacement information for Hessian update.
+        """
+        x0 = self.get_x()
+        dx_initial = target - x0
+
+        # Split target into Cartesian and cell parts
+        x_cart_target = target[:self.n_cart]
+        cell_target = target[self.n_cart:]
+
+        # Get initial cell params
+        cell_params0 = self._masked_cell_params()
+
+        # Update cell first
+        self._set_masked_cell_params(cell_target)
+
+        # Update positions directly (simple for Cartesian!)
+        x_cart0 = self.apos.ravel()
+        diff = x_cart_target - x_cart0
+        self.atoms.positions = x_cart_target.reshape((-1, 3))
+
+        dx_final = np.concatenate([diff, cell_target - cell_params0])
+
+        # Return parallel gradient for Hessian update
+        g_old = self.curr.get('g', None)
+        if g_old is not None:
+            g_par = g_old.copy()
+        else:
+            g_par = np.zeros(self.dim)
+
+        return dx_initial, dx_final, g_par
+
+    def eval(self) -> tuple:
+        """Evaluate energy and combined gradient (Cartesian + cell)."""
+        self.neval += 1
+        f = self.atoms.get_potential_energy()
+
+        # Add pressure contribution: H = E + P*V
+        if self.scalar_pressure != 0.0:
+            f += self.scalar_pressure * self.atoms.get_volume()
+
+        # Cartesian gradient: Sella works in actual Cartesian positions
+        # (not the undeformed frame), so no F transformation needed
+        forces = self.atoms.get_forces()
+        g_cart = -forces.ravel()
+
+        # Stress tensor -> cell gradient
+        stress = self.atoms.get_stress()  # 6-component Voigt, eV/Å³
+        g_cell = self._stress_to_cell_gradient(stress, forces)
+
+        self.write_traj()
+        return f, np.concatenate([g_cart, g_cell])
+
+    def _stress_to_cell_gradient(self, stress_voigt: np.ndarray,
+                                 forces: np.ndarray) -> np.ndarray:
+        """Convert stress tensor to gradient w.r.t. log-deformation cell parameters.
+
+        Uses the Frechet derivative of the matrix exponential to correctly
+        transform dE/dF into dE/dU = dE/d(log F).
+
+        The virial stress V*σ relates to dE/dC via (ASE row-vector convention):
+            V*σ = dE/dC^T @ C - f^T @ r
+
+        So dE/dC = C^{-T} @ (V*σ + r^T @ f)  at fixed Cartesian positions, or
+           dE/dC = C^{-T} @ V*σ              at fixed fractional positions.
+
+        Then dE/dF = dE/dC @ C₀^T via chain rule through cell = F @ C₀.
+        """
+        volume = self.atoms.get_volume()
+        stress_3x3 = voigt_6_to_full_3x3_stress(stress_voigt)
+
+        # Add external pressure contribution
+        if self.scalar_pressure != 0.0:
+            stress_3x3 += self.scalar_pressure * np.eye(3)
+
+        C = self.atoms.get_cell().array
+        C_inv_T = np.linalg.inv(C.T)
+
+        # V*σ from the virial stress
+        virial = volume * stress_3x3
+
+        # In CellCartesianPES, positions are always set independently after
+        # cell changes (set_x overrides any position scaling), so we always
+        # need the fixed-Cartesian gradient: dE/dC = C^{-T} @ (V*σ + r^T @ f)
+        positions = self.atoms.get_positions()
+        dEdC = C_inv_T @ (virial + positions.T @ forces)
+
+        # Chain rule: cell = F @ C₀, so dE/dF = dE/dC @ C₀^T
+        dEdF = dEdC @ self.orig_cell.T
+
+        # Convert dE/dF to dE/dU via Frechet derivative of expm
+        F = self._get_deformation_gradient()
+        U = _logm_3x3(F)
+        g_cell_3x3 = _expm_frechet_3x3_contracted(U, dEdF)
+
+        # Apply cell mask and scale
+        g_cell_3x3 = g_cell_3x3 * self.cell_mask
+        g_cell_3x3 = g_cell_3x3 / self.exp_cell_factor
+
+        return g_cell_3x3[self.cell_mask]
+
+    def _calc_basis(self):
+        """Calculate basis including cell DOF.
+
+        The cell DOF are treated as unconstrained additional coordinates.
+        """
+        # Compute Cartesian basis directly (not via parent, since parent uses self.dim)
+        # This mirrors PES._calc_basis but uses n_cart instead of self.dim
+        state_hash = self._state_hash()
+        cached = self._basis_cache.get(state_hash)
+        if cached is not None:
+            return cached
+
+        drdx_cart = self.cons.jacobian()  # Constraint Jacobian for Cartesian coords
+        U, S, VT = np.linalg.svd(drdx_cart)
+        ncons = np.sum(S > 1e-6)
+        Ucons_cart = VT[:ncons].T
+        Ufree_cart = VT[ncons:].T
+        Unred_cart = np.eye(self.n_cart)
+
+        # Extend to include cell DOF
+        n_total = self.n_cart + self.n_cell_dof
+
+        # drdx extended with zeros for cell columns
+        drdx = np.zeros((drdx_cart.shape[0], n_total))
+        drdx[:, :self.n_cart] = drdx_cart
+
+        # Ucons stays the same (no cell constraints)
+        Ucons = np.zeros((n_total, Ucons_cart.shape[1]))
+        Ucons[:self.n_cart, :] = Ucons_cart
+
+        # Unred extended with identity for cell DOF
+        Unred = np.zeros((n_total, Unred_cart.shape[1] + self.n_cell_dof))
+        Unred[:self.n_cart, :Unred_cart.shape[1]] = Unred_cart
+        Unred[self.n_cart:, Unred_cart.shape[1]:] = np.eye(self.n_cell_dof)
+
+        # Ufree extended with identity for cell DOF
+        Ufree = np.zeros((n_total, Ufree_cart.shape[1] + self.n_cell_dof))
+        Ufree[:self.n_cart, :Ufree_cart.shape[1]] = Ufree_cart
+        Ufree[self.n_cart:, Ufree_cart.shape[1]:] = np.eye(self.n_cell_dof)
+
+        result = drdx, Ucons, Unred, Ufree
+
+        # Cache the result
+        self._basis_cache.put(state_hash, result)
+        return result
+
+    def converged(self, fmax: float, smax: float = None, cmax: float = 1e-5):
+        """Check convergence of forces and stress.
+
+        Parameters
+        ----------
+        fmax : float
+            Maximum force tolerance (eV/Å).
+        smax : float, optional
+            Maximum stress tolerance. If None, uses fmax.
+        cmax : float, optional
+            Constraint residual tolerance.
+
+        Returns
+        -------
+        conv : bool
+            True if converged.
+        fmax_actual : float
+            Maximum force.
+        cmax_actual : float
+            Constraint residual norm.
+        smax_actual : float
+            Maximum stress gradient.
+        """
+        if smax is None:
+            smax = fmax
+
+        # Force convergence (project out constraints)
+        g = self.get_g()
+        g_cart = g[:self.n_cart]
+        Ufree = self.get_Ufree()
+        Ufree_cart = Ufree[:self.n_cart, :Ufree.shape[1] - self.n_cell_dof]
+        g_proj = (Ufree_cart @ (Ufree_cart.T @ g_cart)).reshape((-1, 3))
+
+        fmax_actual = np.linalg.norm(g_proj, axis=1).max()
+
+        # Stress convergence
+        g_cell = g[self.n_cart:]
+        smax_actual = np.abs(g_cell).max() if len(g_cell) > 0 else 0.0
+
+        # Constraint residual
+        cmax_actual = np.linalg.norm(self.get_res())
+
+        conv = (fmax_actual < fmax) and (smax_actual < smax) and (cmax_actual < cmax)
+        return conv, fmax_actual, cmax_actual, smax_actual
+
+    def get_projected_forces(self) -> np.ndarray:
+        """Returns Nx3 array of atomic forces orthogonal to constraints."""
+        g = self.get_g()
+        g_cart = g[:self.n_cart]
+        Ufree = self.get_Ufree()
+        Ufree_cart = Ufree[:self.n_cart, :]
+        return -(Ufree_cart @ (Ufree_cart.T @ g_cart)).reshape((-1, 3))
+
+    def get_drdx(self):
+        """Get constraint Jacobian extended for cell DOF."""
+        drdx_cart = PES.get_drdx(self)
+        n_cons = drdx_cart.shape[0]
+        drdx = np.zeros((n_cons, self.dim))
+        drdx[:, :self.n_cart] = drdx_cart
+        return drdx
+
+    def get_Hc(self):
+        """Get constraint Hessian extended for cell DOF."""
+        Hc_cart = PES.get_Hc(self)
+        Hc = np.zeros((self.dim, self.dim))
+        Hc[:self.n_cart, :self.n_cart] = Hc_cart
+        return Hc

--- a/sella/peswrapper.py
+++ b/sella/peswrapper.py
@@ -1,9 +1,11 @@
+import logging
 from typing import Union, Callable
 
 import numpy as np
-from scipy.linalg import eigh
+from scipy.linalg import eigh, expm, expm_frechet, logm, polar, qr, solve_triangular
 from scipy.integrate import LSODA
 from ase import Atoms
+from ase.build import niggli_reduce
 from ase.utils import basestring
 from ase.visualize import view
 from ase.calculators.singlepoint import SinglePointCalculator
@@ -14,9 +16,191 @@ from sella.hessian_update import symmetrize_Y
 from sella.linalg import NumericalHessian, ApproximateHessian
 from sella.eigensolvers import rayleigh_ritz
 from sella.internal import Internals, Constraints, DuplicateInternalError
+from sella._gpu import gpu_qr as _gpu_qr, gpu_project
+
+logger = logging.getLogger(__name__)
+
+
+class _LRU2:
+    """2-entry LRU cache keyed by state hash (bytes).
+
+    Two entries match the optimization step cycle, which alternates between
+    pre-ODE (post-cell-change) and post-ODE positions.
+    """
+
+    __slots__ = ('_entries', '_next')
+
+    def __init__(self):
+        self._entries = [None, None]
+        self._next = 0
+
+    def get(self, key):
+        for entry in self._entries:
+            if entry is not None and entry[0] == key:
+                return entry[1]
+        return None
+
+    def put(self, key, value):
+        for entry in self._entries:
+            if entry is not None and entry[0] == key:
+                return
+        self._entries[self._next] = (key, value)
+        self._next = 1 - self._next
+
+
+def _split_cons_subspace(drdxnred, tol_factor=1e-6):
+    """Split (n_int) into Ucons (rowspace of drdxnred) and Ufree (its complement).
+
+    Replaces ``np.linalg.svd(drdxnred)`` (which materializes a full
+    n_int×n_int V matrix) with rank-revealing QR on ``drdxnred.T``.
+    For an (m, n) drdxnred with m << n, this is roughly half the cost of
+    the SVD path and returns the same orthonormal subspaces (column order
+    differs but the spans match — every downstream consumer is column-
+    permutation-invariant).
+
+    Returns ``(Ucons, Ufree)`` of shapes (n, ncons) and (n, n - ncons).
+    """
+    Q, R, _ = qr(drdxnred.T, mode='full', pivoting=True, check_finite=False)
+    diag = np.abs(np.diag(R))
+    if diag.size and diag[0] > 0:
+        ncons = int(np.sum(diag > tol_factor * diag[0]))
+    else:
+        ncons = 0
+    return Q[:, :ncons], Q[:, ncons:]
+
+
+def _logm_3x3(F):
+    """Closed-form 3x3 matrix logarithm via eigendecomposition.
+
+    Replaces ``scipy.linalg.logm`` (which uses Padé + inverse-squaring
+    + onenormest, ~0.9ms per call on 3x3) with a direct
+    eigendecomposition: ``log(F) = V diag(log(lam)) V^{-1}``. ~50x
+    faster on 3x3, machine-precision agreement on cell-deformation
+    inputs (real, near-identity, well-conditioned).
+
+    Falls back to scipy.linalg.logm when ``np.linalg.eig`` produces a
+    near-singular eigenvector matrix (defective F). Returns the real
+    part directly since cell deformation gradients are real and have
+    no negative real eigenvalues for any reasonable cell.
+    """
+    lam, V = np.linalg.eig(F)
+    if np.linalg.cond(V) > 1e10:
+        return logm(F)
+    return (V @ np.diag(np.log(lam)) @ np.linalg.inv(V)).real
+
+
+def _expm_frechet_3x3_contracted(U, dEdF):
+    """Compute g[mu,nu] = sum_{ab} d expm(U)[E_munu] * dEdF[a,b] for all 9 (mu,nu).
+
+    Replaces the inner ``9x scipy.linalg.expm_frechet`` loop in the
+    cell-stress-to-gradient conversion. For diagonalizable 3x3 ``U``
+    (which is the typical case for a real positive-definite cell
+    deformation logm), the directional derivative of expm has the
+    Daleckii–Krein closed form
+
+        d expm(U)[E] = V (f(lam) ⊙ (V^{-1} E V)) V^{-1},
+
+    where ``f(a, b) = (e^a - e^b) / (a - b)`` (or ``e^a`` when ``a==b``).
+    Contracting over E_munu and dEdF gives the single matmul chain
+    ``g = real(Vinv.T (f ⊙ (V.T dEdF Vinv.T)) V.T)``. ~25x faster than
+    the scipy loop on 3x3 inputs (0.67 → 0.03 ms/call).
+
+    Falls back to scipy when ``U`` is too close to zero (eigenvectors
+    of a noisy zero matrix are catastrophically ill-conditioned) or
+    when ``np.linalg.eig`` produces a near-singular ``V``.
+    """
+    # When ||U|| ~ 0 the derivative reduces to the identity map E -> E,
+    # so the contracted output is dEdF itself. Avoid eig on a noisy zero.
+    Unorm = np.linalg.norm(U)
+    if Unorm < 1e-10:
+        return dEdF.copy()
+    lam, V = np.linalg.eig(U)
+    if np.linalg.cond(V) > 1e10:
+        # Fall back when the eigenvector basis is too ill-conditioned
+        # for the closed form to be numerically reliable.
+        g = np.zeros((3, 3))
+        for mu in range(3):
+            for nu in range(3):
+                E = np.zeros((3, 3)); E[mu, nu] = 1.0
+                ed = expm_frechet(U, E, compute_expm=False)
+                g[mu, nu] = np.sum(ed * dEdF)
+        return g
+    Vinv = np.linalg.inv(V)
+    expl = np.exp(lam)
+    diff = lam[:, None] - lam[None, :]
+    mask = np.abs(diff) > 1e-12 * max(np.abs(lam).max(), 1.0)
+    safe = np.where(mask, diff, 1.0)
+    fij = np.where(mask, (expl[:, None] - expl[None, :]) / safe, expl[:, None])
+    M = V.T @ dEdF @ Vinv.T
+    return (Vinv.T @ (fij * M) @ V.T).real
+
+
+def _niggli_hessian_transform(atoms, orig_cell, exp_cell_factor, cell_mask):
+    """Compute the Hessian transformation matrix for Niggli reduction.
+
+    The cell DOF are parameterized as elements of L = logm(F) * factor where
+    F = cell @ inv(orig_cell). Niggli reduction changes the lattice basis,
+    so the Hessian must be transformed from the old L-parameterization to the
+    new one. This computes T such that H_new = T^T @ H_old @ T.
+
+    The transformation is derived from the chain rule through the cell-element
+    space: J_old maps old L-perturbations to cell perturbations (via Frechet
+    derivative of expm), J_new maps new L-perturbations (at L=0, since
+    orig_cell is reset). Then T = J_old^{-1} @ J_new.
+
+    Parameters
+    ----------
+    atoms : Atoms
+        The atoms object. Niggli reduction is applied in-place.
+    orig_cell : ndarray, shape (3, 3)
+        The old reference cell (before reduction).
+    exp_cell_factor : float
+        Scaling factor for the log-deformation parameterization.
+    cell_mask : ndarray, shape (3, 3), dtype bool
+        Mask selecting which cell DOF are free.
+
+    Returns
+    -------
+    T_masked : ndarray, shape (n_cell_dof, n_cell_dof)
+        Transformation matrix for the masked cell DOF.
+    """
+    # Compute old Jacobian: J_old[ab, ij] = d(cell_ab)/d(L_ij)
+    # at the current (pre-reduction) L value
+    F_old = atoms.get_cell().array @ np.linalg.inv(orig_cell)
+    X_old = _logm_3x3(F_old) / exp_cell_factor  # unscaled log-deformation
+
+    J_old = np.zeros((9, 9))
+    for idx in range(9):
+        i, j = divmod(idx, 3)
+        E = np.zeros((3, 3))
+        E[i, j] = 1.0 / exp_cell_factor
+        dF = expm_frechet(X_old, E, compute_expm=False)
+        dC = dF @ orig_cell  # d(cell)/d(L_ij)
+        J_old[:, idx] = dC.ravel()
+
+    # Apply Niggli reduction
+    niggli_reduce(atoms)
+    orig_cell_new = atoms.get_cell().array.copy()
+
+    # New Jacobian at L=0: d(cell_ab)/d(L_ij) = (1/factor) * delta_ai * O_jb
+    # In matrix form: J_new = (1/factor) * kron(I_3, orig_cell_new.T)
+    J_new = np.kron(np.eye(3), orig_cell_new.T) / exp_cell_factor
+
+    # T maps new L-perturbations to old L-perturbations (same physical cell change)
+    # δL_old = T @ δL_new, so H_new = T^T @ H_old @ T
+    T_full = np.linalg.solve(J_old, J_new)
+
+    # Project to masked DOF: T_masked = M @ T_full @ M^T
+    mask_flat = cell_mask.ravel()
+    mask_indices = np.where(mask_flat)[0]
+    T_masked = T_full[np.ix_(mask_indices, mask_indices)]
+
+    return T_masked
 
 
 class PES:
+    n_cell_dof = 0
+
     def __init__(
         self,
         atoms: Atoms,
@@ -92,11 +276,18 @@ class PES:
 
         self.hessian_function = hessian_function
 
-        # Cache for _calc_basis to avoid redundant SVD computations
-        self._basis_cache = dict(pos_hash=None, result=None)
+        self._basis_cache = _LRU2()
 
     apos = property(lambda self: self.atoms.positions.copy())
     dpos = property(lambda self: None)
+
+    def _state_hash(self) -> bytes:
+        """Hash of all state that affects cached computations."""
+        h = self.atoms.positions.tobytes()
+        cell = self.atoms.cell
+        if cell is not None and cell.any():
+            h += cell.array.tobytes()
+        return h
 
     def save(self):
         self.savepoint = dict(apos=self.apos, dpos=self.dpos)
@@ -144,11 +335,42 @@ class PES:
 
     # Hessian of the constraints
     def get_Hc(self):
+        if self.curr['L'] is None:
+            raise RuntimeError(
+                "PES.get_Hc() called with L=None. "
+                f"curr_g_is_none={self.curr.get('g') is None}, "
+                f"curr_f_is_none={self.curr.get('f') is None}."
+            )
         return self.cons.hessian().ldot(self.curr['L'])
 
     # Hessian of the Lagrangian
     def get_HL(self):
         return self.get_H() - self.get_Hc()
+
+    def get_HL_projected(self, U):
+        """Projected Hessian of the Lagrangian: ApproximateHessian(U.T @ HL @ U).
+
+        Equivalent to ``self.get_HL().project(U)`` but skips constructing the
+        full (dim, dim) HL matrix and the intermediate ApproximateHessian.
+        """
+        H = self.get_H()
+        H_B = H.B
+        if H_B is None:
+            Bproj = None
+        else:
+            UtHU = gpu_project(H_B, U, H_gpu=H._get_B_gpu())
+            # Skip the constraint projection entirely when there are no
+            # constraints — Hc is allocated as a (dim, dim) zero block in
+            # CellInternalPES, so the matmul would just churn through ~N^3
+            # zeros (and force a 44 MB GPU upload at 400 atoms).
+            L = self.curr.get('L')
+            if L is not None and L.size > 0:
+                Hc = self.get_Hc()
+                Bproj = UtHU - gpu_project(Hc, U)
+            else:
+                Bproj = UtHU
+        n = U.shape[1]
+        return ApproximateHessian(n, 0, Bproj, self.H.update_method, self.H.symm)
 
     # Getters for constraints and their derivatives
     def get_res(self):
@@ -158,22 +380,17 @@ class PES:
         return self.cons.jacobian()
 
     def _calc_basis(self):
-        # Check if cached result is valid
-        pos_hash = self.atoms.positions.tobytes()
-        if self._basis_cache['pos_hash'] == pos_hash:
-            return self._basis_cache['result']
+        state_hash = self._state_hash()
+        cached = self._basis_cache.get(state_hash)
+        if cached is not None:
+            return cached
 
         drdx = self.get_drdx()
-        U, S, VT = np.linalg.svd(drdx)
-        ncons = np.sum(S > 1e-6)
-        Ucons = VT[:ncons].T
-        Ufree = VT[ncons:].T
+        Ucons, Ufree = _split_cons_subspace(drdx)
         Unred = np.eye(self.dim)
         result = (drdx, Ucons, Unred, Ufree)
 
-        # Cache the result
-        self._basis_cache['pos_hash'] = pos_hash
-        self._basis_cache['result'] = result
+        self._basis_cache.put(state_hash, result)
         return result
 
     def write_traj(self):
@@ -208,13 +425,14 @@ class PES:
         return scons
 
     def _update(self, feval=True):
-        x = self.get_x()
+        state = self._state_hash()
         new_point = True
-        if self.curr['x'] is not None and np.all(x == self.curr['x']):
+        if self.curr['x'] is not None and state == self.curr.get('state_hash'):
             if feval and self.curr['f'] is None:
                 new_point = False
             else:
                 return False
+        x = self.get_x()
         basis = self._calc_basis()
 
         if feval:
@@ -227,6 +445,7 @@ class PES:
             self.last = self.curr.copy()
 
         self.curr['x'] = x
+        self.curr['state_hash'] = state
         self.curr['f'] = f
         self.curr['g'] = g
         self._update_basis(basis)
@@ -245,6 +464,7 @@ class PES:
             L = None
         else:
             L = np.linalg.lstsq(drdx.T, self.curr['g'], rcond=None)[0]
+
         self.curr['L'] = L
 
     def _update_H(self, dx, dg):
@@ -256,7 +476,7 @@ class PES:
         self._update()
         return self.curr['f']
 
-    def get_g(self):
+    def get_g(self) -> np.ndarray:
         self._update()
         return self.curr['g'].copy()
 
@@ -283,7 +503,7 @@ class PES:
         if nfree == 0:
             return
 
-        P = self.get_HL().project(Ufree)
+        P = self.get_HL_projected(Ufree)
         P_is_none = P.B is None
 
         # Determine initial guess vector
@@ -322,12 +542,11 @@ class PES:
 
         self.first_diag = False
 
-    # FIXME: temporary functions for backwards compatibility
     def get_projected_forces(self):
         """Returns Nx3 array of atomic forces orthogonal to constraints."""
         g = self.get_g()
         Ufree = self.get_Ufree()
-        return -((Ufree @ Ufree.T) @ g).reshape((-1, 3))
+        return -(Ufree @ (Ufree.T @ g)).reshape((-1, 3))
 
     def converged(self, fmax, cmax=1e-5):
         fmax1 = np.linalg.norm(self.get_projected_forces(), axis=1).max()
@@ -412,7 +631,8 @@ class InternalPES(PES):
             # Construct guess hessian and zero out components in
             # infeasible subspace
             B = self.int.jacobian()
-            P = B @ np.linalg.pinv(B)
+            Q, _ = qr(B, mode='economic')
+            P = Q @ Q.T
             H0 = P @ self.int.guess_hessian() @ P
             self.set_H(H0, initialized=False)
         else:
@@ -422,31 +642,83 @@ class InternalPES(PES):
         self.bad_int = None
         self.iterative_stepper = iterative_stepper
 
-        # Cache for Jacobian pseudo-inverse
-        self._pinv_cache = dict(version=None, pinv=None)
+        self._pinv_cache = _LRU2()
+        self._qr_cache = _LRU2()
+        self._Hc_cache = _LRU2()
 
     dpos = property(lambda self: self.dummies.positions.copy())
 
+    def _state_hash(self) -> bytes:
+        h = super()._state_hash()
+        h += self.dummies.positions.tobytes()
+        return h
+
     # =========================================================================
-    # Cache optimization: Store and reuse Jacobian pseudo-inverse
+    # Cache optimization: Store and reuse Jacobian QR and pseudo-inverse
     # =========================================================================
-    # Computing pinv(B) is expensive. Cache it and use the internal coordinate
-    # system's _cache_version counter to detect when positions have changed.
-    # =========================================================================
+
+    def _get_jacobian_qr(self):
+        """Get cached economy QR of internal Jacobian.
+
+        Returns (Q, R) from np.linalg.qr(B, mode='reduced').
+        Q (m, n) is the orthonormal basis for range(B) (= Unred).
+        R (n, n) upper triangular, with R^{-1} replacing V S^{-1} from SVD.
+
+        Shared between _get_Binv and _calc_basis so the Jacobian is
+        decomposed at most once per geometry.  ~2x faster than SVD.
+        Falls back to SVD if the Jacobian is rank-deficient.
+        """
+        state_hash = self._state_hash()
+        cached = self._qr_cache.get(state_hash)
+        if cached is not None:
+            return cached
+
+        B = self.int.jacobian()
+        Q, R = _gpu_qr(B)
+
+        # Check for rank deficiency via R diagonal
+        rdiag = np.abs(np.diag(R))
+        if len(rdiag) > 0 and rdiag.min() < 1e-6 * rdiag.max():
+            # Rank-deficient: fall back to SVD for safe truncation
+            Ui, Si, VTi = np.linalg.svd(B, full_matrices=False)
+            nnred = np.sum(Si > 1e-6)
+            Q = Ui[:, :nnred]
+            R = np.diag(Si[:nnred]) @ VTi[:nnred]
+
+            # Pre-compute Binv from SVD factors and cache it, since the
+            # non-square R can't be used with solve_triangular in _get_Binv
+            Siinv = np.diag(1.0 / Si[:nnred])
+            Binv = VTi[:nnred].T @ Siinv @ Ui[:, :nnred].T
+            self._pinv_cache.put(state_hash, Binv)
+
+        self._qr_cache.put(state_hash, (Q, R))
+        return Q, R
 
     def _get_Binv(self):
-        """Get cached pseudo-inverse of internal Jacobian."""
-        B = self.int.jacobian()
-        # Use cache version counter to detect changes
-        version = self.int._cache_version
-        if (self._pinv_cache.get('version') == version and
-                self._pinv_cache.get('pinv') is not None):
-            return self._pinv_cache['pinv']
+        """Get cached pseudo-inverse of internal Jacobian.
 
-        Binv = np.linalg.pinv(B)
+        Computes Binv = R^{-1} Q^T from the shared QR cache,
+        using a triangular solve instead of a full SVD.
+        """
+        state_hash = self._state_hash()
+        cached = self._pinv_cache.get(state_hash)
+        if cached is not None:
+            return cached
 
-        self._pinv_cache['version'] = version
-        self._pinv_cache['pinv'] = Binv
+        Q, R = self._get_jacobian_qr()
+        if R.size == 0:
+            ncart = 3 * len(self.atoms) + (3 * len(self.dummies) if self.dummies else 0)
+            Binv = np.empty((ncart, 0))
+        elif R.shape[0] == R.shape[1]:
+            Binv = solve_triangular(R, Q.T, check_finite=False)
+        else:
+            # Non-square R from rank-deficient SVD fallback — Binv should
+            # already have been cached by _get_jacobian_qr, but recompute
+            # as a safety net (e.g., if the 2-entry cache evicted it).
+            B = self.int.jacobian()
+            Binv = np.linalg.pinv(B)
+
+        self._pinv_cache.put(state_hash, Binv)
         return Binv
 
     # =========================================================================
@@ -472,11 +744,7 @@ class InternalPES(PES):
         dx_initial = target - x0
 
         # Get initial gradient in Cartesian space
-        g0 = np.linalg.lstsq(
-            self.int.jacobian(),
-            self.curr.get('g', np.zeros_like(dx_initial)),
-            rcond=None,
-        )[0]
+        g0 = self._get_Binv() @ self.curr.get('g', np.zeros_like(dx_initial))
 
         rms_prev = np.inf
         initial_rms = None
@@ -565,6 +833,7 @@ class InternalPES(PES):
         dx = target - self.get_x()
         t0 = 0.
         Binv = self._get_Binv()
+        self._ode_Binv = Binv
         y0 = np.hstack((self.apos.ravel(), self.dpos.ravel(),
                         Binv @ dx,
                         Binv @ self.curr.get('g', np.zeros_like(dx))))
@@ -605,80 +874,237 @@ class InternalPES(PES):
         if self.iterative_stepper:
             res = self._set_x_iterative(target)
             if res is not None:
-                return res
+                q_after_ode = self.int.calc().copy()
+                proj_moved = self._project_to_constraints()
+                dx_initial, dx_final_ode, g_final = res
+                dx_final = self._add_proj_delta(dx_final_ode, q_after_ode,
+                                                proj_moved)
+                return dx_initial, dx_final, g_final
         # Fall back to ODE solver
-        return self._set_x_ode(target)
+        res = self._set_x_ode(target)
+        q_after_ode = self.int.calc().copy()
+        proj_moved = self._project_to_constraints()
+        dx_initial, dx_final_ode, g_final = res
+        dx_final = self._add_proj_delta(dx_final_ode, q_after_ode, proj_moved)
+        return dx_initial, dx_final, g_final
+
+    def _add_proj_delta(self, dx_int_final, q_after_ode, proj_moved):
+        """Combine ODE-tangent dx with the projection's IC delta.
+
+        ``dx_int_final`` is the tangent-integrated displacement returned
+        by the ODE/iterative stepper — what BFGS expects as the secant.
+        If the projection then nudged atoms, that extra motion is
+        captured as ``delta_proj = int.calc() - q_after_ode`` (raw IC
+        difference, with dihedrals wrapped to (-π, π] for safety).
+        BFGS sees the sum so its `s = dx` matches `dg = g_after - g_before`.
+        """
+        if not proj_moved:
+            return dx_int_final
+        delta_proj = self.int.calc() - q_after_ode
+        dih_start = (self.int.ntrans + self.int.nbonds
+                     + self.int.nangles)
+        dih_end = dih_start + self.int.ndihedrals
+        if dih_end > dih_start:
+            delta_proj[dih_start:dih_end] = (
+                (delta_proj[dih_start:dih_end] + np.pi)
+                % (2 * np.pi) - np.pi
+            )
+        return dx_int_final + delta_proj
+
+    def _project_to_constraints(self, target_tol=1e-7, max_iter=8,
+                                safety_limit=0.05):
+        """Newton projection onto the constraint manifold (IC null-space).
+
+        Drives ``cons.residual()`` to zero with corrections that, to
+        first order, do not change any *free* internal coordinate.
+        This avoids the failure mode of a Cartesian min-norm projection,
+        which would tilt the dummy atom in directions that couple back
+        into the free improper-dihedral bending coordinate.
+
+        Algorithm (one Newton iteration, repeated):
+
+            r       = cons.residual()                          # (ncons,)
+            drdx    = d(cons) / d(int_coords)                   # (ncons, n_int)
+            Ucons   = IC-space basis spanned by constraints     # (n_int, ncons')
+            s       = lstsq(drdx @ Ucons, -r)                   # min-norm in Ucons
+            dq_int  = Ucons @ s                                 # IC-space step
+            dx_cart = Binv @ dq_int                             # back to Cartesian
+
+        Because ``dq_int`` lives entirely in ``Ucons`` (orthogonal to
+        ``Ufree`` in the IC inner product), every free internal — including
+        the improper dihedral that parametrizes a linear-bend — is
+        unchanged to first order. The Cartesian step is the
+        minimum-norm representative of that IC-space step (``Binv`` is
+        the pseudoinverse), so real atoms only move when the
+        constraint *requires* it (e.g. ``FixBondLengths``).
+
+        ``safety_limit`` caps ``|dx_cart|_inf`` per iteration. If the
+        Newton step would exceed it, we bail and accept the partial
+        residual — the alternative (damped re-iteration) was tested
+        and found to *increase* opt step counts (~+30%) on the tier1+2
+        benchmarks because the partial corrections accumulate as
+        Hessian noise. Bailing leaves the projection as a strict
+        improvement: it can only help, never hurt.
+        """
+        if self.cons.residual().size == 0:
+            return False
+
+        n_real = 3 * len(self.atoms)
+        n_dummy = 3 * len(self.dummies)
+        moved = False
+
+        for _ in range(max_iter):
+            r = self.cons.residual()
+            if np.linalg.norm(r, ord=np.inf) < target_tol:
+                return moved
+
+            # _compute_basis_int returns (drdx, Ucons, Unred, Ufree) for the
+            # internal-only block (no cell DOF). drdx is ncons × n_int in
+            # IC space; Ucons is n_int × ncons'.
+            drdx, Ucons, _, _ = self._compute_basis_int()
+            if Ucons.shape[1] == 0:
+                return moved  # no constraint subspace — nothing to project
+
+            s, *_ = np.linalg.lstsq(drdx @ Ucons, -r, rcond=None)
+            dq_int = Ucons @ s                       # IC-space step (n_int,)
+            dx = self._get_Binv() @ dq_int            # Cartesian (n_cart,)
+
+            if np.linalg.norm(dx, ord=np.inf) > safety_limit:
+                return moved  # would override optimizer's step — bail
+
+            self.atoms.positions += dx[:n_real].reshape(-1, 3)
+            if n_dummy > 0:
+                self.dummies.positions += dx[n_real:n_real + n_dummy].reshape(-1, 3)
+            moved = True
+
+        return moved
 
     def get_x(self):
-        return self.int.calc()
+        x = self.int.calc()
+        if self.curr['x'] is not None:
+            dih_start = (self.int.ntrans + self.int.nbonds
+                         + self.int.nangles)
+            dih_end = dih_start + self.int.ndihedrals
+            if dih_end > dih_start:
+                dx = x[dih_start:dih_end] - self.curr['x'][dih_start:dih_end]
+                x[dih_start:dih_end] = (
+                    self.curr['x'][dih_start:dih_end]
+                    + (dx + np.pi) % (2 * np.pi) - np.pi
+                )
+        return x
 
     # Hessian of the constraints
-    def get_Hc(self):
-        D_cons = self.cons.hessian().ldot(self.curr['L'])
+    def _compute_Hc_int(self):
+        """Compute the internal-coords-only constraint Hessian (uncached)."""
+        if self.curr['L'] is None:
+            raise RuntimeError(
+                "InternalPES.get_Hc() called with L=None. "
+                f"curr_g_is_none={self.curr.get('g') is None}, "
+                f"curr_f_is_none={self.curr.get('f') is None}."
+            )
+
+        # No constraints → L is empty → Hc is identically zero. Skip the
+        # expensive ldot/matmul chain (~95ms at 400 atoms).
         Binv_int = self._get_Binv()
+        n_dof = Binv_int.shape[1]
+        if self.curr['L'].size == 0:
+            return np.zeros((n_dof, n_dof))
+
+        D_cons = self.cons.hessian().ldot(self.curr['L'])
         B_cons = self.cons.jacobian()
         L_int = self.curr['L'] @ B_cons @ Binv_int
         D_int = self.int.hessian().ldot(L_int)
-        Hc = Binv_int.T @ (D_cons - D_int) @ Binv_int
+        return Binv_int.T @ (D_cons - D_int) @ Binv_int
+
+    def get_Hc(self):
+        # Subclasses (CellInternalPES) cache the cell-extended form themselves
+        # and call _compute_Hc_int directly, so we only cache here when this
+        # *is* the runtime class.
+        state_hash = self._state_hash()
+        cached = self._Hc_cache.get(state_hash)
+        if cached is not None:
+            return cached
+
+        Hc = self._compute_Hc_int()
+        self._Hc_cache.put(state_hash, Hc)
         return Hc
 
     def get_drdx(self):
         # dr/dq = dr/dx dx/dq
         return PES.get_drdx(self) @ self._get_Binv()
 
+    def _compute_basis_int(self):
+        """Compute the internal-coords-only basis (uncached, fast path).
+
+        Uses the cached jacobian QR factors. Subclasses (CellInternalPES) call
+        this to obtain the internal block, then add their own cell extension
+        and cache the combined result themselves.
+        """
+        cons = self.cons
+        Q, R = self._get_jacobian_qr()
+        Unred = Q
+
+        n_int = Q.shape[0]
+        cons_jac = cons.jacobian()
+        if cons_jac.shape[0] == 0:
+            # No constraints: all non-redundant DOF are free
+            drdx = np.zeros((0, n_int))
+            Ucons = np.zeros((n_int, 0))
+            Ufree = Unred
+        else:
+            if R.shape[0] == R.shape[1]:
+                # Full rank: cons_jac @ R^{-1} via triangular solve
+                drdxnred = solve_triangular(
+                    R.T, cons_jac.T, lower=True, check_finite=False
+                ).T
+            else:
+                # Rank-deficient (SVD fallback in _get_jacobian_qr)
+                Binv = self._get_Binv()
+                drdxnred = cons_jac @ (Binv @ Q)
+            drdx = drdxnred @ Q.T
+            Vcons, Vfree = _split_cons_subspace(drdxnred)
+            Ucons = Unred @ Vcons
+            Ufree = Unred @ Vfree
+        return drdx, Ucons, Unred, Ufree
+
     def _calc_basis(self, internal=None, cons=None):
-        # If custom internal/cons provided, bypass cache
+        # If custom internal/cons provided, bypass cache (used by refine paths)
         if internal is not None or cons is not None:
             if internal is None:
                 internal = self.int
             if cons is None:
                 cons = self.cons
             B = internal.jacobian()
-            Ui, Si, VTi = np.linalg.svd(B)
+            Ui, Si, VTi = np.linalg.svd(B, full_matrices=False)
             nnred = np.sum(Si > 1e-6)
             Unred = Ui[:, :nnred]
             Vnred = VTi[:nnred].T
             Siinv = np.diag(1 / Si[:nnred])
-            drdxnred = cons.jacobian() @ Vnred @ Siinv
-            drdx = drdxnred @ Unred.T
-            Uc, Sc, VTc = np.linalg.svd(drdxnred)
-            ncons = np.sum(Sc > 1e-6)
-            Ucons = Unred @ VTc[:ncons].T
-            Ufree = Unred @ VTc[ncons:].T
+            cons_jac = cons.jacobian()
+            n_int = B.shape[0]
+            if cons_jac.shape[0] == 0:
+                # No constraints: all non-redundant DOF are free
+                drdx = np.zeros((0, n_int))
+                Ucons = np.zeros((n_int, 0))
+                Ufree = Unred
+            else:
+                drdxnred = cons_jac @ Vnred @ Siinv
+                drdx = drdxnred @ Unred.T
+                Vcons, Vfree = _split_cons_subspace(drdxnred)
+                Ucons = Unred @ Vcons
+                Ufree = Unred @ Vfree
             return drdx, Ucons, Unred, Ufree
 
-        # Check if cached result is valid
-        pos_hash = (self.atoms.positions.tobytes() +
-                    self.dummies.positions.tobytes())
-        if self._basis_cache['pos_hash'] == pos_hash:
-            return self._basis_cache['result']
+        # Subclasses (CellInternalPES) cache the cell-extended form themselves
+        # and call _compute_basis_int directly, so we only cache here when
+        # this *is* the runtime class.
+        state_hash = self._state_hash()
+        cached = self._basis_cache.get(state_hash)
+        if cached is not None:
+            return cached
 
-        internal = self.int
-        cons = self.cons
-        B = internal.jacobian()
-        Ui, Si, VTi = np.linalg.svd(B)
-        nnred = np.sum(Si > 1e-6)
-        Unred = Ui[:, :nnred]
-        Vnred = VTi[:nnred].T
-        Siinv = np.diag(1 / Si[:nnred])
-
-        # Compute pinv from SVD components and cache it for _get_Binv
-        # pinv(B) = V @ diag(1/S) @ U.T
-        Binv = Vnred @ Siinv @ Unred.T
-        self._pinv_cache['version'] = internal._cache_version
-        self._pinv_cache['pinv'] = Binv
-
-        drdxnred = cons.jacobian() @ Vnred @ Siinv
-        drdx = drdxnred @ Unred.T
-        Uc, Sc, VTc = np.linalg.svd(drdxnred)
-        ncons = np.sum(Sc > 1e-6)
-        Ucons = Unred @ VTc[:ncons].T
-        Ufree = Unred @ VTc[ncons:].T
-        result = (drdx, Ucons, Unred, Ufree)
-
-        # Cache the result
-        self._basis_cache['pos_hash'] = pos_hash
-        self._basis_cache['result'] = result
+        result = self._compute_basis_int()
+        self._basis_cache.put(state_hash, result)
         return result
 
     def eval(self):
@@ -690,13 +1116,6 @@ class InternalPES(PES):
         self._update(True)
 
         nold = 3 * (len(self.atoms) + len(self.dummies))
-
-        # FIXME: Testing to see if disabling this works
-        #if self.bad_int is not None:
-        #    for bond in self.bad_int['bonds']:
-        #        self.int_orig.forbid_bond(bond)
-        #    for angle in self.bad_int['angles']:
-        #        self.int_orig.forbid_angle(angle)
 
         # Find new internals, constraints, and dummies
         new_int = self.int_orig.copy()
@@ -745,12 +1164,10 @@ class InternalPES(PES):
             return None
         Unred = self.get_Unred()
         dx_r = dx @ Unred
-        # dx_r = self.wrap_dx(dx) @ Unred
         g_r = g @ Unred
         H_r = Unred.T @ H @ Unred
         return g_r.T @ dx_r + (dx_r.T @ H_r @ dx_r) / 2.
 
-    # FIXME: temporary functions for backwards compatibility
     def get_projected_forces(self):
         """Returns Nx3 array of atomic forces orthogonal to constraints."""
         g = self.get_g()
@@ -760,7 +1177,7 @@ class InternalPES(PES):
             B = self.curr['B']
         else:
             B = self.int.jacobian()
-        return -((Ufree @ Ufree.T) @ g @ B).reshape((-1, 3))
+        return -(Ufree @ (Ufree.T @ g) @ B).reshape((-1, 3))
 
     def wrap_dx(self, dx):
         return self.int.wrap(dx)
@@ -777,22 +1194,20 @@ class InternalPES(PES):
         self.atoms.positions = x[:nxa].reshape((-1, 3)).copy()
         self.dummies.positions = x[nxa:].reshape((-1, 3)).copy()
 
-        # Use direct HVP computation instead of forming full Hessians
+        # Use direct HVP computation instead of forming full Hessians.
+        # Batch the two D_rdot @ vector products into one (D_rdot @ matrix)
+        # matmul, then one Binv @ matrix matmul, halving the matmul count.
         D_rdot = self.int.hessian_rdot(dxdt)
-        Binv = np.linalg.pinv(self.int.jacobian())
-        D_tmp = -Binv @ D_rdot
-        dydt[1] = D_tmp @ dxdt
-        dydt[2] = D_tmp @ g
+        Binv = self._ode_Binv
+        rhs = np.column_stack((dxdt, g))     # (ndof, 2)
+        out = -Binv @ (D_rdot @ rhs)          # (ndof, 2)
+        dydt[1] = out[:, 0]
+        dydt[2] = out[:, 1]
 
         return dydt.ravel()
 
     def kick(self, dx, diag=False, **diag_kwargs):
         ratio = PES.kick(self, dx, diag=diag, **diag_kwargs)
-
-        # FIXME: Testing to see if this works
-        #if self.bad_int is not None:
-        #    self.update_internals(dx)
-        #    self.bad_int = None
 
         return ratio
 
@@ -822,7 +1237,7 @@ class InternalPES(PES):
         ncart = 3 * len(self.atoms)
         # Get Jacobian and calculate redundant and non-redundant spaces
         B = self.int.jacobian()[:, :ncart]
-        Ui, Si, VTi = np.linalg.svd(B)
+        Ui, Si, VTi = np.linalg.svd(B, full_matrices=True)
         nnred = np.sum(Si > 1e-6)
         Unred = Ui[:, :nnred]
         Ured = Ui[:, nnred:]
@@ -857,3 +1272,34 @@ class InternalPES(PES):
         self.H.set_B(self._convert_cartesian_hessian_to_internal(
             self.hessian_function(self.atoms)
         ))
+
+
+# =============================================================================
+# Utility functions for cell optimization
+# =============================================================================
+
+def voigt_6_to_full_3x3_stress(stress_voigt: np.ndarray) -> np.ndarray:
+    """Convert 6-component Voigt stress to full 3x3 stress tensor.
+
+    ASE uses the convention: [xx, yy, zz, yz, xz, xy]
+    """
+    xx, yy, zz, yz, xz, xy = stress_voigt
+    return np.array([
+        [xx, xy, xz],
+        [xy, yy, yz],
+        [xz, yz, zz]
+    ])
+
+
+def full_3x3_to_voigt_6_stress(stress_3x3: np.ndarray) -> np.ndarray:
+    """Convert 3x3 stress tensor to 6-component Voigt notation."""
+    return np.array([
+        stress_3x3[0, 0],  # xx
+        stress_3x3[1, 1],  # yy
+        stress_3x3[2, 2],  # zz
+        stress_3x3[1, 2],  # yz
+        stress_3x3[0, 2],  # xz
+        stress_3x3[0, 1],  # xy
+    ])
+
+

--- a/tests/test_cell_optimization.py
+++ b/tests/test_cell_optimization.py
@@ -1,0 +1,1737 @@
+"""Tests for unit cell optimization functionality."""
+
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+
+from ase import Atoms
+from ase.build import bulk, molecule
+from ase.calculators.emt import EMT
+from ase.calculators.lj import LennardJones
+
+from sella import Sella
+from sella.peswrapper import CellInternalPES, CellCartesianPES
+from sella.internal import Internals, Bond, Angle
+
+
+def make_molecular_crystal():
+    """Create a simple periodic molecular system for testing.
+
+    Uses methane (CH4) in a periodic box, which has well-defined
+    bonds and angles that work reliably with internal coordinates.
+    """
+    mol = molecule('CH4')
+    # Place in a box with padding
+    mol.center(vacuum=3.0)
+    mol.pbc = True
+    return mol
+
+
+def make_water_crystal():
+    """Create a water molecule in a periodic box."""
+    mol = molecule('H2O')
+    mol.center(vacuum=3.0)
+    mol.pbc = True
+    return mol
+
+
+class TestCellDerivatives:
+    """Test cell derivative functions for internal coordinates."""
+
+    def test_bond_cell_derivative_numerical_molecular(self):
+        """Verify bond cell derivative against numerical finite difference.
+
+        Uses a molecular system with explicit bonds that cross the periodic
+        boundary when the cell is compressed.
+        """
+        # Create CH4 in a periodic cell
+        atoms = make_molecular_crystal()
+
+        # Create internals and find bonds (C-H bonds)
+        internals = Internals(atoms)
+        internals.find_all_bonds()
+
+        assert len(internals.internals['bonds']) > 0, "No bonds found"
+
+        # Test the first bond
+        bond = internals.internals['bonds'][0]
+
+        # Analytical gradient
+        grad_analytic = bond.calc_cell_gradient(atoms)
+
+        # Numerical gradient using finite differences
+        delta = 1e-5
+        cell0 = atoms.get_cell().array.copy()
+        grad_numeric = np.zeros((3, 3))
+
+        for i in range(3):
+            for j in range(3):
+                # Forward
+                cell_plus = cell0.copy()
+                cell_plus[i, j] += delta
+                atoms.set_cell(cell_plus, scale_atoms=False)
+                val_plus = bond.calc(atoms)
+
+                # Backward
+                cell_minus = cell0.copy()
+                cell_minus[i, j] -= delta
+                atoms.set_cell(cell_minus, scale_atoms=False)
+                val_minus = bond.calc(atoms)
+
+                grad_numeric[i, j] = (val_plus - val_minus) / (2 * delta)
+
+        # Restore cell
+        atoms.set_cell(cell0, scale_atoms=False)
+
+        assert_allclose(grad_analytic, grad_numeric, atol=1e-6, rtol=1e-5)
+
+    def test_bond_cell_derivative_with_periodic_image(self):
+        """Test bond cell derivative for bond crossing periodic boundary.
+
+        Create a diatomic that spans the periodic boundary to ensure
+        ncvec contribution to cell derivative is tested.
+        """
+        # Create H2 spanning the periodic boundary
+        atoms = Atoms('H2', positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 2.5]])
+        atoms.set_cell([3.0, 3.0, 3.0])
+        atoms.pbc = True
+
+        # Create a bond that crosses the boundary (using ncvec)
+        # Bond between atom 0 and atom 1 via periodic image
+        bond = Bond(
+            indices=np.array([0, 1], dtype=np.int32),
+            ncvecs=np.array([[0, 0, -1]], dtype=np.int32)  # Wrap in -z direction
+        )
+
+        # Analytical gradient
+        grad_analytic = bond.calc_cell_gradient(atoms)
+
+        # Numerical gradient
+        delta = 1e-5
+        cell0 = atoms.get_cell().array.copy()
+        grad_numeric = np.zeros((3, 3))
+
+        for i in range(3):
+            for j in range(3):
+                cell_plus = cell0.copy()
+                cell_plus[i, j] += delta
+                atoms.set_cell(cell_plus, scale_atoms=False)
+                val_plus = bond.calc(atoms)
+
+                cell_minus = cell0.copy()
+                cell_minus[i, j] -= delta
+                atoms.set_cell(cell_minus, scale_atoms=False)
+                val_minus = bond.calc(atoms)
+
+                grad_numeric[i, j] = (val_plus - val_minus) / (2 * delta)
+
+        atoms.set_cell(cell0, scale_atoms=False)
+
+        # The bond crosses the boundary, so cell derivatives should be non-zero
+        assert not np.allclose(grad_analytic, 0), "Cell gradient should be non-zero for PBC bond"
+        assert_allclose(grad_analytic, grad_numeric, atol=1e-6, rtol=1e-5)
+
+    def test_angle_cell_derivative_numerical(self):
+        """Verify angle cell derivative against numerical finite difference."""
+        # Use water - has a well-defined H-O-H angle
+        atoms = make_water_crystal()
+
+        internals = Internals(atoms)
+        internals.find_all_bonds()
+        internals.find_all_angles()
+
+        if not internals.internals['angles']:
+            pytest.skip("No angles found in structure")
+
+        # Get an angle (H-O-H)
+        angle = internals.internals['angles'][0]
+
+        # Analytical gradient
+        grad_analytic = angle.calc_cell_gradient(atoms)
+
+        # Numerical gradient
+        delta = 1e-5
+        cell0 = atoms.get_cell().array.copy()
+        grad_numeric = np.zeros((3, 3))
+
+        for i in range(3):
+            for j in range(3):
+                cell_plus = cell0.copy()
+                cell_plus[i, j] += delta
+                atoms.set_cell(cell_plus, scale_atoms=False)
+                val_plus = angle.calc(atoms)
+
+                cell_minus = cell0.copy()
+                cell_minus[i, j] -= delta
+                atoms.set_cell(cell_minus, scale_atoms=False)
+                val_minus = angle.calc(atoms)
+
+                grad_numeric[i, j] = (val_plus - val_minus) / (2 * delta)
+
+        atoms.set_cell(cell0, scale_atoms=False)
+
+        assert_allclose(grad_analytic, grad_numeric, atol=1e-6, rtol=1e-5)
+
+    def test_cell_jacobian_shape(self):
+        """Test that cell_jacobian returns correct shape."""
+        atoms = make_molecular_crystal()  # CH4 with bonds and angles
+
+        internals = Internals(atoms)
+        internals.find_all_bonds()
+        internals.find_all_angles()
+
+        J_cell = internals.cell_jacobian()
+
+        # Should have shape (n_active_coords, 9)
+        n_active = len(internals.calc())
+        assert J_cell.shape == (n_active, 9)
+
+
+class TestCellInternalPES:
+    """Test CellInternalPES class."""
+
+    def test_cell_internal_pes_initialization(self):
+        """Test that CellInternalPES initializes correctly."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        internals = Internals(atoms)
+        pes = CellInternalPES(atoms, internals)
+
+        # Check dimensions include cell DOF
+        assert pes.n_cell_dof == 9  # Full 3x3 cell
+        assert pes.dim == pes.n_internal + 9
+
+    def test_cell_internal_pes_get_x(self):
+        """Test get_x returns combined internal + cell vector."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        internals = Internals(atoms)
+        pes = CellInternalPES(atoms, internals)
+
+        x = pes.get_x()
+
+        # Length should be n_internal + n_cell_dof
+        assert len(x) == pes.dim
+
+        # First n_internal elements are internal coords
+        q = internals.calc()
+        assert_allclose(x[:pes.n_internal], q, rtol=1e-10)
+
+        # Cell params at identity should be approximately zero
+        # (log of identity matrix is zero)
+        assert_allclose(x[pes.n_internal:], 0, atol=1e-10)
+
+    def test_cell_internal_pes_cell_mask(self):
+        """Test cell_mask parameter."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # Only allow diagonal elements (hydrostatic strain)
+        cell_mask = np.eye(3, dtype=bool)
+
+        internals = Internals(atoms)
+        pes = CellInternalPES(atoms, internals, cell_mask=cell_mask)
+
+        assert pes.n_cell_dof == 3  # Only 3 diagonal elements
+        assert pes.dim == pes.n_internal + 3
+
+    def test_cell_internal_pes_eval(self):
+        """Test eval returns correct gradient shape."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        internals = Internals(atoms)
+        pes = CellInternalPES(atoms, internals)
+
+        f, g = pes.eval()
+
+        assert isinstance(f, float)
+        assert len(g) == pes.dim
+
+
+class TestCellCartesianPES:
+    """Test CellCartesianPES class."""
+
+    def test_cell_cartesian_pes_initialization(self):
+        """Test that CellCartesianPES initializes correctly."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms)
+
+        # Check dimensions include cell DOF
+        assert pes.n_cell_dof == 9  # Full 3x3 cell
+        assert pes.n_cart == 3 * len(atoms)
+        assert pes.dim == pes.n_cart + 9
+
+    def test_cell_cartesian_pes_get_x(self):
+        """Test get_x returns combined Cartesian + cell vector."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms)
+
+        x = pes.get_x()
+
+        # Length should be n_cart + n_cell_dof
+        assert len(x) == pes.dim
+
+        # First n_cart elements are Cartesian positions
+        positions_flat = atoms.get_positions().ravel()
+        assert_allclose(x[:pes.n_cart], positions_flat, rtol=1e-10)
+
+        # Cell params at identity should be approximately zero
+        # (log of identity matrix is zero)
+        assert_allclose(x[pes.n_cart:], 0, atol=1e-10)
+
+    def test_cell_cartesian_pes_cell_mask(self):
+        """Test cell_mask parameter."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # Only allow diagonal elements (hydrostatic strain)
+        cell_mask = np.eye(3, dtype=bool)
+
+        pes = CellCartesianPES(atoms, cell_mask=cell_mask)
+
+        assert pes.n_cell_dof == 3  # Only 3 diagonal elements
+        assert pes.dim == pes.n_cart + 3
+
+    def test_cell_cartesian_pes_eval(self):
+        """Test eval returns correct gradient shape."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms)
+
+        f, g = pes.eval()
+
+        assert isinstance(f, float)
+        assert len(g) == pes.dim
+
+    def test_cell_cartesian_pes_save_restore(self):
+        """Test save and restore functionality."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms)
+
+        # Save initial state
+        pes.save()
+        x0 = pes.get_x()
+        cell0 = atoms.get_cell().array.copy()
+        pos0 = atoms.get_positions().copy()
+
+        # Modify positions and cell
+        atoms.positions += 0.1
+        new_cell = atoms.get_cell().array * 1.05
+        atoms.set_cell(new_cell, scale_atoms=False)
+
+        # Verify modifications took effect
+        assert not np.allclose(atoms.get_positions(), pos0)
+        assert not np.allclose(atoms.get_cell().array, cell0)
+
+        # Restore and verify
+        pes.restore()
+        assert_allclose(atoms.get_positions(), pos0)
+        assert_allclose(atoms.get_cell().array, cell0)
+
+    def test_cell_cartesian_pes_set_x(self):
+        """Test set_x updates positions and cell."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms)
+
+        # Get initial x
+        x0 = pes.get_x()
+
+        # Create target with small perturbations
+        x_target = x0.copy()
+        x_target[:pes.n_cart] += 0.01  # Small position change
+        x_target[pes.n_cart:] += 0.001  # Small cell change
+
+        # Set new x
+        pes.set_x(x_target)
+
+        # Get x and verify it's close to target
+        x_new = pes.get_x()
+        # Cell parameters should match
+        assert_allclose(x_new[pes.n_cart:], x_target[pes.n_cart:], rtol=1e-6)
+        # Positions should match
+        assert_allclose(x_new[:pes.n_cart], x_target[:pes.n_cart], rtol=1e-6)
+
+    def test_cell_cartesian_vs_internal_gradient_shape(self):
+        """Compare CellCartesianPES and CellInternalPES gradient shapes."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # CellCartesianPES
+        pes_cart = CellCartesianPES(atoms.copy())
+        pes_cart.atoms.calc = EMT()
+        _, g_cart = pes_cart.eval()
+
+        # CellInternalPES
+        internals = Internals(atoms)
+        pes_int = CellInternalPES(atoms, internals)
+        _, g_int = pes_int.eval()
+
+        # Both should have 9 cell DOF (full 3x3 cell)
+        assert pes_cart.n_cell_dof == 9
+        assert pes_int.n_cell_dof == 9
+
+        # Cell parts of gradient should have same length
+        assert len(g_cart[pes_cart.n_cart:]) == len(g_int[pes_int.n_internal:])
+
+    def test_cell_cartesian_pes_pressure(self):
+        """Test scalar pressure contribution."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # Without pressure
+        pes_no_p = CellCartesianPES(atoms.copy())
+        pes_no_p.atoms.calc = EMT()
+        f_no_p, _ = pes_no_p.eval()
+
+        # With pressure
+        pressure = 0.1  # eV/Å³
+        atoms2 = atoms.copy()
+        atoms2.calc = EMT()
+        pes_p = CellCartesianPES(atoms2, scalar_pressure=pressure)
+        f_p, _ = pes_p.eval()
+
+        # Energy with pressure should be higher (positive pressure)
+        volume = atoms.get_volume()
+        expected_diff = pressure * volume
+        assert_allclose(f_p - f_no_p, expected_diff, rtol=1e-10)
+
+
+class TestCellCartesianGradient:
+    """Test cell gradient calculations in CellCartesianPES."""
+
+    def test_cell_gradient_numerical(self):
+        """Test cell gradient matches numerical finite difference for bulk Cu."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms)
+
+        # Get analytical gradient
+        _, g = pes.eval()
+        g_cell = g[pes.n_cart:]  # Cell part of gradient
+
+        # Numerical gradient via finite difference on cell parameters
+        delta = 1e-6
+        x0 = pes.get_x()
+        g_cell_numeric = np.zeros(pes.n_cell_dof)
+
+        for i in range(pes.n_cell_dof):
+            pes.set_x(x0)  # Restore before each probe
+            x_plus = x0.copy()
+            x_plus[pes.n_cart + i] += delta
+            pes.set_x(x_plus)
+            e_plus, _ = pes.eval()
+
+            pes.set_x(x0)  # Restore before -delta
+            x_minus = x0.copy()
+            x_minus[pes.n_cart + i] -= delta
+            pes.set_x(x_minus)
+            e_minus, _ = pes.eval()
+
+            g_cell_numeric[i] = (e_plus - e_minus) / (2 * delta)
+
+        pes.set_x(x0)
+
+        assert_allclose(g_cell, g_cell_numeric, atol=1e-4, rtol=1e-3)
+
+    def test_cartesian_gradient_numerical(self):
+        """Test Cartesian gradient matches numerical finite difference."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms)
+
+        # Get analytical gradient
+        _, g = pes.eval()
+        g_cart = g[:pes.n_cart]  # Cartesian part of gradient
+
+        # Numerical gradient via finite difference
+        delta = 1e-6
+        x0 = pes.get_x()
+        g_cart_numeric = np.zeros(pes.n_cart)
+
+        for i in range(pes.n_cart):
+            pes.set_x(x0)  # Restore before each probe
+            x_plus = x0.copy()
+            x_plus[i] += delta
+            pes.set_x(x_plus)
+            e_plus, _ = pes.eval()
+
+            pes.set_x(x0)  # Restore before -delta
+            x_minus = x0.copy()
+            x_minus[i] -= delta
+            pes.set_x(x_minus)
+            e_minus, _ = pes.eval()
+
+            g_cart_numeric[i] = (e_plus - e_minus) / (2 * delta)
+
+        pes.set_x(x0)
+
+        assert_allclose(g_cart, g_cart_numeric, atol=1e-4, rtol=1e-3)
+
+
+class TestSellaWithCellOptimization:
+    """Integration tests for Sella with cell optimization."""
+
+    def test_sella_optimize_cell_parameter(self):
+        """Test that optimize_cell parameter is properly handled."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        opt = Sella(atoms, internal=True, order=0, optimize_cell=True)
+
+        assert opt.optimize_cell is True
+        assert isinstance(opt.pes, CellInternalPES)
+
+    def test_sella_cell_optimization_validation(self):
+        """Test validation of cell optimization parameters."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # Should fail with order != 0
+        with pytest.raises(ValueError, match="order=0"):
+            Sella(atoms, internal=True, order=1, optimize_cell=True)
+
+        # internal=False with optimize_cell=True should use CellCartesianPES
+        atoms2 = atoms.copy()
+        atoms2.calc = EMT()
+        opt = Sella(atoms2, internal=False, order=0, optimize_cell=True)
+        assert isinstance(opt.pes, CellCartesianPES)
+
+        # Should fail without PBC
+        atoms_nopbc = atoms.copy()
+        atoms_nopbc.pbc = False
+        atoms_nopbc.calc = EMT()
+        with pytest.raises(ValueError, match="periodic"):
+            Sella(atoms_nopbc, internal=True, order=0, optimize_cell=True)
+
+    def test_sella_cell_optimization_single_step(self):
+        """Test that cell optimization can take a single step."""
+        # Use strained FCC copper
+        atoms = bulk('Cu', 'fcc', a=3.8)  # Slightly expanded
+        atoms.calc = EMT()
+
+        opt = Sella(atoms, internal=True, order=0, optimize_cell=True)
+
+        # Record initial state
+        cell0 = atoms.get_cell().array.copy()
+        e0 = atoms.get_potential_energy()
+
+        # Take one step
+        opt.step()
+
+        # Energy should decrease (or at least be computed)
+        e1 = atoms.get_potential_energy()
+        # Cell should change
+        cell1 = atoms.get_cell().array
+
+        # At least something should have changed
+        assert not np.allclose(cell0, cell1) or not np.isclose(e0, e1)
+
+    @pytest.mark.slow
+    def test_sella_cell_optimization_convergence(self):
+        """Test that cell optimization converges for a simple system."""
+        # Create strained FCC copper - use single primitive cell
+        # (larger supercells have issues with angle finding in FCC)
+        # Note: bulk() creates a primitive cell, so a=3.8 gives cell param ~2.69 Å
+        atoms = bulk('Cu', 'fcc', a=3.8)  # Slightly expanded
+        atoms.calc = EMT()
+
+        opt = Sella(
+            atoms,
+            internal=True,
+            order=0,
+            optimize_cell=True,
+            logfile=None,
+        )
+
+        # Run optimization
+        converged = opt.run(fmax=0.05, steps=50)
+
+        if converged:
+            # Check that cell relaxed toward equilibrium
+            # EMT equilibrium for FCC Cu primitive cell is about a = 2.54 Å
+            a = atoms.get_cell().cellpar()[0]
+            assert 2.4 < a < 2.7
+
+
+    def test_gradient_converged_delegates_to_converged(self):
+        """Test that gradient_converged routes through converged().
+
+        ASE 3.28 changed irun() to call gradient_converged() instead of
+        converged(), bypassing Sella's stress check. This test verifies
+        that Sella's gradient_converged override delegates to converged(),
+        so the stress convergence check is always reached.
+        """
+        atoms = bulk('Cu', 'fcc', a=3.8)  # Strained → nonzero stress
+        atoms.calc = EMT()
+
+        opt = Sella(atoms, internal=True, order=0, optimize_cell=True,
+                    logfile=None)
+
+        # Force evaluation so pes has cached gradient
+        opt.pes.eval()
+
+        # converged() should check stress; with a strained cell and tight
+        # tolerance, it should report not converged
+        opt.fmax = 1e-10
+        opt.smax = 1e-10
+        assert not opt.converged()
+
+        # gradient_converged must agree (it delegates to converged)
+        assert not opt.gradient_converged()
+
+        # Now with loose tolerances, both should agree on convergence
+        opt.fmax = 100.0
+        opt.smax = 100.0
+        assert opt.converged()
+        assert opt.gradient_converged()
+
+
+class TestVoigtConversion:
+    """Test Voigt stress conversion functions."""
+
+    def test_voigt_roundtrip(self):
+        """Test conversion roundtrip."""
+        from sella.peswrapper import voigt_6_to_full_3x3_stress, full_3x3_to_voigt_6_stress
+
+        # Random Voigt stress
+        voigt = np.random.randn(6)
+
+        # Convert to 3x3 and back
+        stress_3x3 = voigt_6_to_full_3x3_stress(voigt)
+        voigt_back = full_3x3_to_voigt_6_stress(stress_3x3)
+
+        assert_allclose(voigt, voigt_back)
+
+    def test_voigt_symmetry(self):
+        """Test that converted tensor is symmetric."""
+        from sella.peswrapper import voigt_6_to_full_3x3_stress
+
+        voigt = np.array([1, 2, 3, 4, 5, 6])
+        stress_3x3 = voigt_6_to_full_3x3_stress(voigt)
+
+        assert_allclose(stress_3x3, stress_3x3.T)
+
+
+class TestStressTensor:
+    """Test stress tensor calculations for cell optimization."""
+
+    def test_stress_changes_with_strain_inorganic(self):
+        """Test that stress changes when cell is strained for bulk Cu."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+        stress_ref = atoms.get_stress()
+
+        # Strain the cell
+        atoms_strained = bulk('Cu', 'fcc', a=3.8)  # Different lattice constant
+        atoms_strained.calc = EMT()
+        stress_strained = atoms_strained.get_stress()
+
+        # Stress should change
+        assert not np.allclose(stress_ref, stress_strained)
+
+        # Stress should be finite
+        assert np.all(np.isfinite(stress_ref))
+        assert np.all(np.isfinite(stress_strained))
+
+    def test_stress_finite_molecular(self):
+        """Test stress is finite for molecular system (CH4 in periodic box)."""
+        # Create CH4 in a periodic box
+        mol = molecule('CH4')
+        mol.center(vacuum=4.0)
+        mol.pbc = True
+        mol.calc = EMT()
+
+        # Should be able to get stress without error
+        stress_voigt = mol.get_stress()
+        assert len(stress_voigt) == 6
+        assert np.all(np.isfinite(stress_voigt))
+
+
+class TestCellGradient:
+    """Test cell gradient calculations in CellInternalPES."""
+
+    def test_cell_gradient_numerical_inorganic(self):
+        """Test cell gradient matches numerical finite difference for bulk Cu."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        internals = Internals(atoms)
+        pes = CellInternalPES(atoms, internals)
+
+        # Get analytical gradient
+        _, g = pes.eval()
+        g_cell = g[pes.n_internal:]  # Cell part of gradient
+
+        # Numerical gradient via finite difference on cell parameters
+        delta = 1e-6
+        x0 = pes.get_x()
+        g_cell_numeric = np.zeros(pes.n_cell_dof)
+
+        for i in range(pes.n_cell_dof):
+            pes.set_x(x0)  # Restore before each probe
+            x_plus = x0.copy()
+            x_plus[pes.n_internal + i] += delta
+            pes.set_x(x_plus)
+            e_plus, _ = pes.eval()
+
+            pes.set_x(x0)  # Restore before -delta
+            x_minus = x0.copy()
+            x_minus[pes.n_internal + i] -= delta
+            pes.set_x(x_minus)
+            e_minus, _ = pes.eval()
+
+            g_cell_numeric[i] = (e_plus - e_minus) / (2 * delta)
+
+        pes.set_x(x0)
+
+        assert_allclose(g_cell, g_cell_numeric, atol=1e-4, rtol=1e-3)
+
+    def test_cell_gradient_shape_molecular(self):
+        """Test cell gradient has correct shape for molecular system."""
+        water1 = molecule('H2O')
+        water2 = molecule('H2O')
+        water1.positions += [1.0, 1.0, 1.0]
+        water2.positions += [4.0, 4.0, 4.0]
+        mol = water1 + water2
+        mol.set_cell([7.0, 7.0, 7.0])
+        mol.pbc = True
+        mol.calc = LennardJones()
+
+        internals = Internals(mol, allow_fragments=True)
+        pes = CellInternalPES(mol, internals, auto_find_internals=True)
+
+        _, g = pes.eval()
+
+        # Gradient should have n_internal + n_cell_dof components
+        assert len(g) == pes.n_internal + pes.n_cell_dof
+
+        # All components should be finite
+        assert np.all(np.isfinite(g))
+
+
+class TestMolecularCrystal:
+    """Test cell optimization for molecular crystal systems.
+
+    Molecular crystals have multiple separate molecules in a periodic cell,
+    requiring TRICs (Translation-Rotation Internal Coordinates) for proper
+    handling of each molecular fragment.
+    """
+
+    def test_molecular_crystal_with_trics(self):
+        """Test that molecular crystal optimization works with allow_fragments=True."""
+        # Create a simple molecular crystal: two water molecules in a box
+        water1 = molecule('H2O')
+        water2 = molecule('H2O')
+
+        # Place molecules in different parts of the cell
+        water1.positions += [1.0, 1.0, 1.0]
+        water2.positions += [4.0, 4.0, 4.0]
+
+        # Combine into one system
+        atoms = water1 + water2
+        atoms.set_cell([7.0, 7.0, 7.0])
+        atoms.pbc = True
+        atoms.calc = LennardJones()
+
+        # Create optimizer with allow_fragments=True for TRICs
+        opt = Sella(
+            atoms,
+            internal=True,
+            order=0,
+            optimize_cell=True,
+            allow_fragments=True,
+            logfile=None,
+        )
+
+        assert isinstance(opt.pes, CellInternalPES)
+
+        # Verify the internal coords have TRICs (translations and rotations)
+        internals = opt.pes.int
+        assert internals.ntrans > 0, "Should have translation coordinates for fragments"
+        assert internals.nrotations > 0, "Should have rotation coordinates for fragments"
+
+        # Take a few steps to verify no errors
+        for _ in range(3):
+            opt.step()
+
+    def test_molecular_crystal_cartesian(self):
+        """Test molecular crystal optimization with Cartesian coordinates."""
+        # Create two methane molecules
+        ch4_1 = molecule('CH4')
+        ch4_2 = molecule('CH4')
+
+        ch4_1.positions += [1.5, 1.5, 1.5]
+        ch4_2.positions += [5.0, 5.0, 5.0]
+
+        atoms = ch4_1 + ch4_2
+        atoms.set_cell([8.0, 8.0, 8.0])
+        atoms.pbc = True
+        atoms.calc = LennardJones()
+
+        # Use Cartesian coordinates (internal=False) with cell optimization
+        opt = Sella(
+            atoms,
+            internal=False,
+            order=0,
+            optimize_cell=True,
+            logfile=None,
+        )
+
+        assert isinstance(opt.pes, CellCartesianPES)
+
+        # Take a few steps
+        for _ in range(3):
+            opt.step()
+
+    def test_molecular_crystal_trics_dof_count(self):
+        """Test that TRICs add correct DOF for molecular fragments."""
+        # Create two separate H2 molecules
+        atoms = Atoms(
+            'H4',
+            positions=[
+                [0.0, 0.0, 0.0],
+                [0.74, 0.0, 0.0],
+                [4.0, 4.0, 4.0],
+                [4.74, 4.0, 4.0],
+            ]
+        )
+        atoms.set_cell([8.0, 8.0, 8.0])
+        atoms.pbc = True
+        atoms.calc = LennardJones()
+
+        # With allow_fragments=True, should get TRICs for each fragment
+        internals = Internals(atoms, allow_fragments=True)
+        internals.find_all_bonds()
+
+        # Should have 2 bonds (one per H2)
+        assert internals.nbonds == 2
+
+        # Should have translations for the 2 fragments
+        assert internals.ntrans > 0
+
+        # Should have rotations for fragments that can rotate
+        # (H2 is linear, so rotation DOF may be limited)
+        assert internals.nrotations >= 0
+
+
+class TestTRICsCellDerivatives:
+    """Test that TRICs have correct cell derivatives.
+
+    For molecular crystals, translation and rotation coordinates should
+    have zero cell derivatives since they describe internal molecular
+    motion that doesn't depend on the cell.
+    """
+
+    def test_translation_cell_derivative_zero(self):
+        """Test that translation coordinates have zero cell derivatives."""
+        # Create a simple diatomic in a periodic cell
+        atoms = Atoms('H2', positions=[[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
+        atoms.set_cell([5.0, 5.0, 5.0])
+        atoms.pbc = True
+
+        internals = Internals(atoms, allow_fragments=True)
+        internals.find_all_bonds()
+
+        # Get the translation coordinates
+        translations = internals.internals.get('translations', [])
+
+        for trans in translations:
+            grad_cell = trans.calc_cell_gradient(atoms)
+            # Translation center of mass should not depend on cell
+            assert_allclose(grad_cell, 0, atol=1e-10)
+
+    def test_rotation_cell_derivative_zero(self):
+        """Test that rotation coordinates have zero cell derivatives."""
+        # Create water molecule (non-linear, has rotations)
+        atoms = molecule('H2O')
+        atoms.center(vacuum=3.0)
+        atoms.pbc = True
+
+        internals = Internals(atoms, allow_fragments=True)
+        internals.find_all_bonds()
+        internals.find_all_angles()
+
+        # Get rotation coordinates
+        rotations = internals.internals.get('rotations', [])
+
+        for rot in rotations:
+            grad_cell = rot.calc_cell_gradient(atoms)
+            # Rotation orientation should not depend on cell
+            assert_allclose(grad_cell, 0, atol=1e-10)
+
+    def test_bond_cell_derivative_intramolecular(self):
+        """Test intramolecular bond has zero cell derivative if not crossing PBC."""
+        # Create H2 well within the cell (not crossing boundary)
+        atoms = Atoms('H2', positions=[[2.0, 2.5, 2.5], [2.74, 2.5, 2.5]])
+        atoms.set_cell([5.0, 5.0, 5.0])
+        atoms.pbc = True
+
+        internals = Internals(atoms)
+        internals.find_all_bonds()
+
+        bond = internals.internals['bonds'][0]
+
+        # For intramolecular bond not crossing PBC, cell derivative should be zero
+        # (the ncvec should be zero)
+        grad_cell = bond.calc_cell_gradient(atoms)
+
+        # Check that gradient is zero (bond doesn't cross boundary)
+        assert_allclose(grad_cell, 0, atol=1e-10)
+
+    def test_cell_jacobian_trics_rows_zero(self):
+        """Test that TRICs rows in cell_jacobian are zero."""
+        atoms = molecule('H2O')
+        atoms.center(vacuum=3.0)
+        atoms.pbc = True
+
+        internals = Internals(atoms, allow_fragments=True)
+        internals.find_all_bonds()
+        internals.find_all_angles()
+
+        J_cell = internals.cell_jacobian()
+
+        # The rows corresponding to translations and rotations should be zero
+        # First ntrans rows are translations
+        n_trans = internals.ntrans
+        n_rot = internals.nrotations
+
+        if n_trans > 0:
+            trans_rows = J_cell[:n_trans, :]
+            assert_allclose(trans_rows, 0, atol=1e-10)
+
+        # Last nrotations rows are rotations (after other coords)
+        if n_rot > 0:
+            # Rotations come after: trans, bonds, angles, dihedrals, other
+            rot_start = n_trans + internals.nbonds + internals.nangles + internals.ndihedrals + internals.nother
+            rot_rows = J_cell[rot_start:rot_start + n_rot, :]
+            assert_allclose(rot_rows, 0, atol=1e-10)
+
+
+class TestCellConstraints:
+    """Test cell optimization with various constraints."""
+
+    def test_hydrostatic_only_dof_count(self):
+        """Test that hydrostatic constraint gives correct number of DOF."""
+        atoms = bulk('Cu', 'fcc', a=3.8)
+        atoms.calc = EMT()
+
+        # Only allow diagonal elements
+        cell_mask = np.eye(3, dtype=bool)
+
+        opt = Sella(
+            atoms,
+            internal=True,
+            order=0,
+            optimize_cell=True,
+            cell_mask=cell_mask,
+            logfile=None,
+        )
+
+        # Check that only 3 cell DOF (diagonal elements)
+        assert opt.pes.n_cell_dof == 3
+
+    def test_isotropic_scaling(self):
+        """Test cell optimization with isotropic scaling only (1 DOF)."""
+        atoms = bulk('Cu', 'fcc', a=3.8)
+        atoms.calc = EMT()
+
+        # Only allow uniform scaling (first diagonal element)
+        cell_mask = np.zeros((3, 3), dtype=bool)
+        cell_mask[0, 0] = True
+
+        opt = Sella(
+            atoms,
+            internal=True,
+            order=0,
+            optimize_cell=True,
+            cell_mask=cell_mask,
+            logfile=None,
+        )
+
+        assert opt.pes.n_cell_dof == 1
+
+    def test_no_shear_mask(self):
+        """Test that shear components can be masked out."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # Allow all 9 components (full cell optimization)
+        full_mask = np.ones((3, 3), dtype=bool)
+        opt_full = Sella(
+            atoms.copy(),
+            internal=True,
+            order=0,
+            optimize_cell=True,
+            cell_mask=full_mask,
+            logfile=None,
+        )
+        atoms.calc = EMT()  # Reset
+
+        # Allow only diagonal (no shear)
+        diag_mask = np.eye(3, dtype=bool)
+        opt_diag = Sella(
+            atoms,
+            internal=True,
+            order=0,
+            optimize_cell=True,
+            cell_mask=diag_mask,
+            logfile=None,
+        )
+
+        assert opt_full.pes.n_cell_dof == 9
+        assert opt_diag.pes.n_cell_dof == 3
+
+
+class TestRefineInitialHessian:
+    """Test the refine_initial_hessian option for cell optimization."""
+
+    def test_refine_hessian_produces_nonzero_coupling(self):
+        """Test that refine_initial_hessian produces non-zero coupling blocks."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # With refinement
+        pes_refined = CellInternalPES(
+            atoms,
+            Internals(atoms),
+            refine_initial_hessian=True,
+        )
+
+        H = pes_refined.H.B
+        n_int = pes_refined.n_internal
+
+        # The coupling block should be non-zero (or at least the cell-cell block
+        # should differ from 70*I)
+        H_coupling = H[:n_int, n_int:]
+        H_cell = H[n_int:, n_int:]
+
+        # Cell-cell block should not be exactly 70*I (it was computed via FD)
+        # Note: it might still be close to diagonal for simple systems
+        assert H_cell.shape == (pes_refined.n_cell_dof, pes_refined.n_cell_dof)
+
+    def test_refine_hessian_vs_default_different(self):
+        """Test that refined Hessian differs from default."""
+        # Without refinement
+        atoms1 = bulk('Cu', 'fcc', a=3.6)
+        atoms1.calc = EMT()
+        pes_default = CellInternalPES(
+            atoms1,
+            Internals(atoms1),
+            refine_initial_hessian=False,
+        )
+
+        # With refinement
+        atoms2 = bulk('Cu', 'fcc', a=3.6)
+        atoms2.calc = EMT()
+        pes_refined = CellInternalPES(
+            atoms2,
+            Internals(atoms2),
+            refine_initial_hessian=True,
+        )
+
+        H_default = pes_default.H.B
+        H_refined = pes_refined.H.B
+
+        n_int = pes_default.n_internal
+
+        # The cell-cell blocks should be different
+        H_cell_default = H_default[n_int:, n_int:]
+        H_cell_refined = H_refined[n_int:, n_int:]
+
+        # Default is 70*I, refined should be computed from actual curvature
+        assert not np.allclose(H_cell_default, H_cell_refined)
+
+    def test_refine_hessian_cartesian_pes(self):
+        """Test refine_initial_hessian with CellCartesianPES."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(
+            atoms,
+            refine_initial_hessian=True,
+        )
+
+        H = pes.H.B
+        n_cart = pes.n_cart
+
+        # Hessian should have correct shape
+        assert H.shape == (pes.dim, pes.dim)
+
+        # Cell-cell block should exist
+        H_cell = H[n_cart:, n_cart:]
+        assert H_cell.shape == (pes.n_cell_dof, pes.n_cell_dof)
+
+    def test_refine_hessian_via_sella_api(self):
+        """Test refine_initial_hessian through Sella API."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        opt = Sella(
+            atoms,
+            internal=True,
+            order=0,
+            optimize_cell=True,
+            refine_initial_hessian=True,
+            logfile=None,
+        )
+
+        # Should be CellInternalPES
+        assert isinstance(opt.pes, CellInternalPES)
+
+        # Hessian should be properly dimensioned
+        H = opt.pes.H.B
+        assert H.shape == (opt.pes.dim, opt.pes.dim)
+
+    def test_refine_hessian_force_call_count(self):
+        """Test that refinement makes expected number of force calls."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # Only allow diagonal cell DOF for fewer calls
+        cell_mask = np.eye(3, dtype=bool)  # 3 DOF
+
+        pes = CellInternalPES(
+            atoms,
+            Internals(atoms),
+            cell_mask=cell_mask,
+            refine_initial_hessian=True,
+        )
+
+        # Should have made 2 * n_cell_dof = 6 evaluations during init
+        # (2 per cell DOF for central difference)
+        assert pes.neval == 6
+
+
+class TestRigidFragments:
+    """Test rigid fragment mode for molecular crystal cell optimization."""
+
+    def _make_two_water_crystal(self, cell_diag=7.0):
+        """Create two water molecules in a periodic box."""
+        water1 = molecule('H2O')
+        water2 = molecule('H2O')
+        water1.positions += [1.0, 1.0, 1.0]
+        water2.positions += [4.0, 4.0, 4.0]
+        atoms = water1 + water2
+        atoms.set_cell([cell_diag, cell_diag, cell_diag])
+        atoms.pbc = True
+        atoms.calc = LennardJones()
+        return atoms
+
+    def test_rigid_fragments_auto_detected(self):
+        """Test that rigid_fragments is auto-detected from allow_fragments."""
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+
+        pes = CellInternalPES(atoms, internals)
+        assert pes.rigid_fragments is True
+        assert hasattr(pes, 'fragment_groups')
+        assert len(pes.fragment_groups) == 2  # Two water molecules
+
+    def test_rigid_fragments_not_detected_without_fragments(self):
+        """Test that rigid_fragments is False when no translations exist."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+        internals = Internals(atoms)
+
+        pes = CellInternalPES(atoms, internals)
+        assert pes.rigid_fragments is False
+
+    def test_rigid_fragments_explicit_override(self):
+        """Test that rigid_fragments can be explicitly set."""
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+
+        # Explicitly disable
+        pes = CellInternalPES(atoms, internals, rigid_fragments=False)
+        assert pes.rigid_fragments is False
+
+    def test_fragment_groups_correct_atoms(self):
+        """Test that fragment groups contain the correct atom indices."""
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+
+        pes = CellInternalPES(atoms, internals)
+
+        # Each group should have 3 atoms (water has O, H, H)
+        for group in pes.fragment_groups:
+            assert len(group) == 3
+
+        # All atoms should be covered
+        all_atoms = np.sort(np.concatenate(pes.fragment_groups))
+        assert_allclose(all_atoms, np.arange(6))
+
+    def test_compute_delta_r(self):
+        """Test that _compute_delta_r gives positions relative to fragment CoM."""
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+
+        pes = CellInternalPES(atoms, internals)
+        delta_r = pes._compute_delta_r()
+
+        # For each fragment, the mean of delta_r should be zero
+        for group in pes.fragment_groups:
+            assert_allclose(delta_r[group].mean(axis=0), 0, atol=1e-12)
+
+    def test_rigid_fragment_cell_gradient_numerical(self):
+        """Test rigid fragment cell gradient matches numerical finite difference.
+
+        This is the key correctness test: the analytical cell gradient with
+        rigid fragment mode should match the energy change when we actually
+        move fragment CoMs to maintain fractional positions.
+        """
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+
+        pes = CellInternalPES(atoms, internals)
+        assert pes.rigid_fragments is True
+
+        # Get analytical gradient
+        _, g = pes.eval()
+        g_cell = g[pes.n_internal:]
+
+        # Numerical gradient via finite difference on cell parameters
+        delta = 1e-6
+        x0 = pes.get_x()
+        g_cell_numeric = np.zeros(pes.n_cell_dof)
+
+        for i in range(pes.n_cell_dof):
+            pes.set_x(x0)  # Restore before each probe
+            x_plus = x0.copy()
+            x_plus[pes.n_internal + i] += delta
+            pes.set_x(x_plus)
+            e_plus, _ = pes.eval()
+
+            pes.set_x(x0)  # Restore before -delta
+            x_minus = x0.copy()
+            x_minus[pes.n_internal + i] -= delta
+            pes.set_x(x_minus)
+            e_minus, _ = pes.eval()
+
+            g_cell_numeric[i] = (e_plus - e_minus) / (2 * delta)
+
+        pes.set_x(x0)
+
+        assert_allclose(g_cell, g_cell_numeric, atol=1e-4, rtol=1e-3)
+
+    def test_rigid_fragment_cell_gradient_nonorthogonal(self):
+        """Test rigid fragment gradient with non-orthogonal cell."""
+        water1 = molecule('H2O')
+        water2 = molecule('H2O')
+        water1.positions += [1.0, 1.0, 1.0]
+        water2.positions += [4.0, 4.0, 4.0]
+        atoms = water1 + water2
+
+        # Non-orthogonal cell (triclinic)
+        cell = np.array([
+            [7.0, 0.5, 0.3],
+            [0.0, 6.8, 0.4],
+            [0.0, 0.0, 7.2],
+        ])
+        atoms.set_cell(cell)
+        atoms.pbc = True
+        atoms.calc = LennardJones()
+
+        internals = Internals(atoms, allow_fragments=True)
+
+        pes = CellInternalPES(atoms, internals)
+        assert pes.rigid_fragments is True
+
+        # Get analytical gradient
+        _, g = pes.eval()
+        g_cell = g[pes.n_internal:]
+
+        # Numerical gradient
+        delta = 1e-6
+        x0 = pes.get_x()
+        g_cell_numeric = np.zeros(pes.n_cell_dof)
+
+        for i in range(pes.n_cell_dof):
+            pes.set_x(x0)  # Restore before each probe
+            x_plus = x0.copy()
+            x_plus[pes.n_internal + i] += delta
+            pes.set_x(x_plus)
+            e_plus, _ = pes.eval()
+
+            pes.set_x(x0)  # Restore before -delta
+            x_minus = x0.copy()
+            x_minus[pes.n_internal + i] -= delta
+            pes.set_x(x_minus)
+            e_minus, _ = pes.eval()
+
+            g_cell_numeric[i] = (e_plus - e_minus) / (2 * delta)
+
+        pes.set_x(x0)
+
+        assert_allclose(g_cell, g_cell_numeric, atol=1e-4, rtol=1e-3)
+
+    def test_intramolecular_geometry_preserved_after_cell_step(self):
+        """Test that intramolecular geometry is preserved after a cell-only step."""
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+
+        pes = CellInternalPES(atoms, internals)
+
+        # Record initial bond lengths and angles
+        q0 = internals.calc()
+        x0 = pes.get_x()
+
+        # Apply a cell-only displacement (change cell params, keep internal targets)
+        x_target = x0.copy()
+        x_target[pes.n_internal:] += 0.01  # Small uniform cell strain
+
+        pes.set_x(x_target)
+
+        # Get new internal coordinates
+        q1 = internals.calc()
+
+        # Internal coords (bonds, angles) should be close to original
+        # The internal coord solver handles the small residual
+        n_trans = internals.ntrans
+        # Skip translations (those change with cell), check bonds/angles
+        assert_allclose(q0[n_trans:], q1[n_trans:], atol=1e-3)
+
+    def test_monoatomic_rigid_fragments_trivial(self):
+        """For monoatomic crystals, Δr=0 so rigid_fragments correction vanishes."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        # Create internals with allow_fragments - each atom is its own "fragment"
+        internals_frag = Internals(atoms, allow_fragments=True)
+        has_translations = bool(internals_frag.internals.get('translations', []))
+
+        if not has_translations:
+            # No fragments detected for monoatomic - this is expected
+            # Just verify rigid_fragments defaults to False
+            pes = CellInternalPES(atoms, internals_frag)
+            assert pes.rigid_fragments is False
+            return
+
+        # If fragments are detected, verify Δr=0 behavior
+        pes_rigid = CellInternalPES(atoms, internals_frag, rigid_fragments=True)
+        delta_r = pes_rigid._compute_delta_r()
+        assert_allclose(delta_r, 0, atol=1e-12)
+
+    def test_rigid_fragments_sella_integration(self):
+        """Test rigid fragments through the Sella API."""
+        atoms = self._make_two_water_crystal()
+
+        opt = Sella(
+            atoms,
+            internal=True,
+            order=0,
+            optimize_cell=True,
+            allow_fragments=True,
+            logfile=None,
+        )
+
+        assert isinstance(opt.pes, CellInternalPES)
+        assert opt.pes.rigid_fragments is True
+
+        # Take a few steps to verify no errors
+        for _ in range(3):
+            opt.step()
+
+    def test_rotation_applied_on_shear(self):
+        """Test that fragment atoms rotate under shear, not just translate."""
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+        pes = CellInternalPES(atoms, internals)
+
+        x0 = pes.get_x()
+        pos0 = atoms.get_positions().copy()
+
+        # Apply a pure shear cell displacement (off-diagonal log-deformation)
+        x_shear = x0.copy()
+        # Find an off-diagonal cell DOF (shear)
+        cell_mask = pes.cell_mask
+        offdiag_indices = []
+        for idx, (i, j) in enumerate(zip(*np.where(cell_mask))):
+            if i != j:
+                offdiag_indices.append(idx)
+        if not offdiag_indices:
+            pytest.skip("No off-diagonal cell DOF available")
+
+        shear_idx = offdiag_indices[0]
+        x_shear[pes.n_internal + shear_idx] += 0.05
+
+        pes.set_x(x_shear)
+        pos_after = atoms.get_positions().copy()
+
+        # For each fragment, check that the relative geometry changed orientation
+        # (rotation applied) but bond lengths are preserved
+        for group in pes.fragment_groups:
+            dr_before = pos0[group] - pos0[group].mean(axis=0)
+            dr_after = pos_after[group] - pos_after[group].mean(axis=0)
+
+            # Bond lengths should be nearly preserved
+            dists_before = np.linalg.norm(dr_before, axis=1)
+            dists_after = np.linalg.norm(dr_after, axis=1)
+            assert_allclose(dists_before, dists_after, atol=1e-3)
+
+            # But the orientation should have changed (dr_after != dr_before)
+            # The rotation under shear should produce a nonzero angular change
+            if len(group) > 1:
+                diff = dr_after - dr_before
+                assert np.max(np.abs(diff)) > 1e-6, (
+                    "Fragment atoms should rotate under shear deformation"
+                )
+
+    def test_gradient_numerical_large_shear(self):
+        """Test gradient correctness with a heavily sheared cell.
+
+        This stress-tests the rotation correction at large deformation
+        where the rotation component R deviates significantly from identity.
+        """
+        water1 = molecule('H2O')
+        water2 = molecule('H2O')
+        water1.positions += [1.0, 1.0, 1.0]
+        water2.positions += [4.0, 4.0, 4.0]
+        atoms = water1 + water2
+
+        # Heavily sheared triclinic cell
+        cell = np.array([
+            [7.0, 1.5, 0.8],
+            [0.0, 6.5, 1.2],
+            [0.0, 0.0, 7.5],
+        ])
+        atoms.set_cell(cell)
+        atoms.pbc = True
+        atoms.calc = LennardJones()
+
+        internals = Internals(atoms, allow_fragments=True)
+        pes = CellInternalPES(atoms, internals)
+        assert pes.rigid_fragments is True
+
+        # Get analytical gradient
+        _, g = pes.eval()
+        g_cell = g[pes.n_internal:]
+
+        # Numerical gradient via finite difference
+        delta = 1e-6
+        x0 = pes.get_x()
+        g_cell_numeric = np.zeros(pes.n_cell_dof)
+
+        for i in range(pes.n_cell_dof):
+            pes.set_x(x0)
+            x_plus = x0.copy()
+            x_plus[pes.n_internal + i] += delta
+            pes.set_x(x_plus)
+            e_plus, _ = pes.eval()
+
+            pes.set_x(x0)
+            x_minus = x0.copy()
+            x_minus[pes.n_internal + i] -= delta
+            pes.set_x(x_minus)
+            e_minus, _ = pes.eval()
+
+            g_cell_numeric[i] = (e_plus - e_minus) / (2 * delta)
+
+        pes.set_x(x0)
+
+        assert_allclose(g_cell, g_cell_numeric, atol=1e-4, rtol=1e-3)
+
+    def test_gradient_after_cell_step(self):
+        """Test gradient correctness after the cell has already been deformed.
+
+        After a cell step, F != I and the rotation correction is nonzero.
+        Verify gradient still matches numerical FD at the deformed geometry.
+        """
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+        pes = CellInternalPES(atoms, internals)
+
+        # First, apply a cell deformation to move away from F = I
+        x0 = pes.get_x()
+        x_deformed = x0.copy()
+        # Apply a mix of diagonal and off-diagonal strains
+        n_cell = pes.n_cell_dof
+        for i in range(n_cell):
+            x_deformed[pes.n_internal + i] += 0.02 * ((-1)**i)
+        pes.set_x(x_deformed)
+
+        # Now verify gradient at this deformed state
+        _, g = pes.eval()
+        g_cell = g[pes.n_internal:]
+
+        delta = 1e-6
+        x1 = pes.get_x()
+        g_cell_numeric = np.zeros(n_cell)
+
+        for i in range(n_cell):
+            pes.set_x(x1)
+            x_plus = x1.copy()
+            x_plus[pes.n_internal + i] += delta
+            pes.set_x(x_plus)
+            e_plus, _ = pes.eval()
+
+            pes.set_x(x1)
+            x_minus = x1.copy()
+            x_minus[pes.n_internal + i] -= delta
+            pes.set_x(x_minus)
+            e_minus, _ = pes.eval()
+
+            g_cell_numeric[i] = (e_plus - e_minus) / (2 * delta)
+
+        pes.set_x(x1)
+
+        assert_allclose(g_cell, g_cell_numeric, atol=1e-4, rtol=1e-3)
+
+    def _full_gradient_fd(self, pes, delta_int=1e-5, delta_cell=1e-6):
+        """Compute full numerical gradient via central finite differences."""
+        _, g_analytical = pes.eval()
+        x0 = pes.get_x()
+        g_numeric = np.zeros(pes.dim)
+
+        for i in range(pes.dim):
+            delta = delta_cell if i >= pes.n_internal else delta_int
+
+            pes.set_x(x0)
+            x_plus = x0.copy()
+            x_plus[i] += delta
+            pes.set_x(x_plus)
+            e_plus, _ = pes.eval()
+
+            pes.set_x(x0)
+            x_minus = x0.copy()
+            x_minus[i] -= delta
+            pes.set_x(x_minus)
+            e_minus, _ = pes.eval()
+
+            g_numeric[i] = (e_plus - e_minus) / (2 * delta)
+
+        pes.set_x(x0)
+        return g_analytical, g_numeric
+
+    def test_full_gradient_numerical_rigid_fragments(self):
+        """Verify analytical gradient matches FD for ALL DOFs (internal + cell)."""
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+        pes = CellInternalPES(atoms, internals)
+        assert pes.rigid_fragments is True
+
+        g_analytical, g_numeric = self._full_gradient_fd(pes)
+        assert_allclose(g_analytical, g_numeric, atol=1e-4, rtol=1e-3)
+
+    def test_full_gradient_numerical_triclinic(self):
+        """Verify full gradient with non-orthogonal cell (rotation correction active)."""
+        water1 = molecule('H2O')
+        water2 = molecule('H2O')
+        water1.positions += [1.0, 1.0, 1.0]
+        water2.positions += [4.0, 4.0, 4.0]
+        atoms = water1 + water2
+
+        cell = np.array([
+            [7.0, 0.5, 0.3],
+            [0.0, 6.8, 0.4],
+            [0.0, 0.0, 7.2],
+        ])
+        atoms.set_cell(cell)
+        atoms.pbc = True
+        atoms.calc = LennardJones()
+
+        internals = Internals(atoms, allow_fragments=True)
+        pes = CellInternalPES(atoms, internals)
+        assert pes.rigid_fragments is True
+
+        g_analytical, g_numeric = self._full_gradient_fd(pes)
+        assert_allclose(g_analytical, g_numeric, atol=1e-4, rtol=1e-3)
+
+    def test_full_gradient_numerical_after_deformation(self):
+        """Verify full gradient after cell deformation (F != I)."""
+        atoms = self._make_two_water_crystal()
+        internals = Internals(atoms, allow_fragments=True)
+        pes = CellInternalPES(atoms, internals)
+
+        x0 = pes.get_x()
+        x_deformed = x0.copy()
+        for i in range(pes.n_cell_dof):
+            x_deformed[pes.n_internal + i] += 0.02 * ((-1)**i)
+        pes.set_x(x_deformed)
+
+        g_analytical, g_numeric = self._full_gradient_fd(pes)
+        assert_allclose(g_analytical, g_numeric, atol=1e-4, rtol=1e-3)
+
+    def test_rotation_correction_nonzero_under_shear(self):
+        """Verify that the rotation correction to the gradient is nonzero
+        when the cell is sheared (so R != I in polar decomposition)."""
+        from scipy.linalg import polar
+
+        water1 = molecule('H2O')
+        water2 = molecule('H2O')
+        water1.positions += [1.0, 1.0, 1.0]
+        water2.positions += [4.0, 4.0, 4.0]
+        atoms = water1 + water2
+
+        # Start with orthogonal cell, then deform with shear
+        atoms.set_cell([7.0, 7.0, 7.0])
+        atoms.pbc = True
+        atoms.calc = LennardJones()
+
+        internals = Internals(atoms, allow_fragments=True)
+        pes = CellInternalPES(atoms, internals)
+
+        # Apply shear to move away from R = I
+        x0 = pes.get_x()
+        x_sheared = x0.copy()
+        cell_mask = pes.cell_mask
+        offdiag_indices = []
+        for idx, (i, j) in enumerate(zip(*np.where(cell_mask))):
+            if i != j:
+                offdiag_indices.append(idx)
+        if not offdiag_indices:
+            pytest.skip("No off-diagonal cell DOF")
+
+        x_sheared[pes.n_internal + offdiag_indices[0]] += 0.05
+        pes.set_x(x_sheared)
+
+        # At this point F should have a nontrivial rotation component
+        F = pes._get_deformation_gradient()
+        R, U = polar(F)
+        assert not np.allclose(R, np.eye(3), atol=1e-6), (
+            "R should differ from identity after shear"
+        )
+
+
+class TestNiggliReduction:
+    """Tests for periodic Niggli reduction during cell optimization."""
+
+    def test_niggli_triggers_on_skewed_cell_cartesian(self):
+        """CellCartesianPES.maybe_niggli_reduce fires when angles are extreme."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms, eta=1e-4)
+
+        # Shear the cell to create a skewed angle
+        cell = atoms.get_cell().array.copy()
+        cell[1, 0] += 3.0  # Large off-diagonal shear
+        atoms.set_cell(cell, scale_atoms=True)
+        pes.orig_cell = atoms.get_cell().array.copy()
+
+        # Shear further so cell relative to orig_cell is identity but
+        # the cell itself is skewed
+        angles = atoms.get_cell().angles()
+        assert min(angles) < 60.0 or max(angles) > 120.0, (
+            f"Test setup: cell should be skewed, got angles {angles}"
+        )
+
+        reduced = pes.maybe_niggli_reduce()
+        assert reduced, "Niggli reduction should have been triggered"
+
+        # After reduction, angles should be closer to 90
+        new_angles = atoms.get_cell().angles()
+        new_max_dev = max(abs(a - 90.0) for a in new_angles)
+        assert new_max_dev <= 30.0 + 1e-10, (
+            f"After Niggli reduction, angles should be near 90, got {new_angles}"
+        )
+
+        # orig_cell should be updated
+        assert_allclose(pes.orig_cell, atoms.get_cell().array)
+
+    def test_niggli_triggers_on_skewed_cell_internal(self):
+        """CellInternalPES.maybe_niggli_reduce fires when angles are extreme."""
+        atoms = make_molecular_crystal()
+        atoms.calc = EMT()
+
+        internals = Internals(atoms, allow_fragments=True)
+        pes = CellInternalPES(atoms, internals=internals, eta=1e-4)
+
+        # Shear the cell
+        cell = atoms.get_cell().array.copy()
+        cell[1, 0] += 6.0
+        atoms.set_cell(cell, scale_atoms=False)
+        pes.orig_cell = atoms.get_cell().array.copy()
+
+        angles = atoms.get_cell().angles()
+        assert min(angles) < 60.0 or max(angles) > 120.0
+
+        reduced = pes.maybe_niggli_reduce()
+        assert reduced
+
+        new_angles = atoms.get_cell().angles()
+        new_max_dev = max(abs(a - 90.0) for a in new_angles)
+        assert new_max_dev < 30.0, f"Angles after reduction: {new_angles}"
+
+    def test_niggli_does_not_trigger_on_good_cell(self):
+        """No reduction when cell angles are fine."""
+        atoms = bulk('Cu', 'fcc', a=3.6)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms, eta=1e-4)
+
+        # Cubic cell — angles are all 60 or 90 depending on conventional vs primitive
+        # Use conventional cell to get 90 degree angles
+        atoms2 = bulk('Cu', 'fcc', a=3.6, cubic=True)
+        atoms2.calc = EMT()
+        pes2 = CellCartesianPES(atoms2, eta=1e-4)
+
+        reduced = pes2.maybe_niggli_reduce()
+        assert not reduced, "Should not reduce a cubic cell"
+
+    def test_niggli_transforms_hessian_cell_block(self):
+        """After Niggli reduction, cell block of Hessian is transformed."""
+        atoms = bulk('Cu', 'fcc', a=3.6, cubic=True)
+        atoms.calc = EMT()
+
+        pes = CellCartesianPES(atoms, eta=1e-4)
+        n = pes.n_cart
+
+        # Set Hessian to identity for cell block to track the transformation
+        H = pes.H.B.copy()
+        H[n:, n:] = np.eye(pes.n_cell_dof)
+        H[:n, n:] = 0.0
+        H[n:, :n] = 0.0
+        pes.set_H(H, initialized=True)
+
+        # Shear the cell to trigger reduction
+        cell = atoms.get_cell().array.copy()
+        cell[1, 0] += 5.0
+        atoms.set_cell(cell, scale_atoms=True)
+        pes.orig_cell = atoms.get_cell().array.copy()
+
+        pes.maybe_niggli_reduce()
+
+        H_new = pes.H.B
+        # Cell block should be transformed (T^T @ I @ T = T^T @ T), symmetric
+        H_cell = H_new[n:, n:]
+        assert_allclose(H_cell, H_cell.T, atol=1e-10)
+        # Should not be identity (transformation is non-trivial for skewed cell)
+        assert not np.allclose(H_cell, np.eye(pes.n_cell_dof), atol=0.1)
+        # Cartesian block should be preserved
+        assert_allclose(H_new[:n, :n], H[:n, :n])
+
+    def test_niggli_in_sella_step(self):
+        """Niggli reduction integrates with Sella.step() without crashing."""
+        atoms = bulk('Cu', 'fcc', a=3.6, cubic=True)
+        atoms.calc = EMT()
+
+        opt = Sella(atoms, order=0, optimize_cell=True, niggli=True,
+                    logfile=None)
+
+        # Shear the cell to extreme angles
+        cell = atoms.get_cell().array.copy()
+        cell[1, 0] += 5.0
+        atoms.set_cell(cell, scale_atoms=True)
+        opt.pes.orig_cell = atoms.get_cell().array.copy()
+
+        # Run a few steps — should not crash even if Niggli fires
+        for _ in range(3):
+            opt.step()
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/test_core_functionality.py
+++ b/tests/test_core_functionality.py
@@ -13,6 +13,7 @@ import numpy as np
 from ase.build import molecule
 from ase.calculators.emt import EMT
 
+from sella import Sella
 from sella.linalg import ApproximateHessian, NumericalHessian, SparseInternalHessians
 from sella.internal import Internals
 from sella.peswrapper import PES, InternalPES
@@ -278,3 +279,29 @@ class TestNumericalHessian:
 
         # Check symmetry
         np.testing.assert_allclose(H12, H21, rtol=1e-5)
+
+
+class TestLinearMolecule:
+    """Test that linear molecules (e.g. N2) don't produce NaN in rotation
+    constraints.
+
+    Linear molecules have degenerate eigenvalues in the quaternion-based
+    rotation parameterization, which previously caused NaN in second
+    derivatives and zeroed Jacobians due to jnp.sign(0)==0.
+    """
+
+    def test_n2_cartesian(self):
+        """Test N2 optimization in Cartesian coordinates."""
+        atoms = molecule('N2')
+        atoms.calc = EMT()
+        opt = Sella(atoms, order=0, logfile=None)
+        opt.run(fmax=0.01, steps=100)
+        assert opt.converged()
+
+    def test_n2_internal(self):
+        """Test N2 optimization with internal coordinates (TRICs)."""
+        atoms = molecule('N2')
+        atoms.calc = EMT()
+        opt = Sella(atoms, order=0, internal=True, logfile=None)
+        opt.run(fmax=0.01, steps=100)
+        assert opt.converged()

--- a/tests/test_core_functionality.py
+++ b/tests/test_core_functionality.py
@@ -13,7 +13,6 @@ import numpy as np
 from ase.build import molecule
 from ase.calculators.emt import EMT
 
-from sella import Sella
 from sella.linalg import ApproximateHessian, NumericalHessian, SparseInternalHessians
 from sella.internal import Internals
 from sella.peswrapper import PES, InternalPES
@@ -279,29 +278,3 @@ class TestNumericalHessian:
 
         # Check symmetry
         np.testing.assert_allclose(H12, H21, rtol=1e-5)
-
-
-class TestLinearMolecule:
-    """Test that linear molecules (e.g. N2) don't produce NaN in rotation
-    constraints.
-
-    Linear molecules have degenerate eigenvalues in the quaternion-based
-    rotation parameterization, which previously caused NaN in second
-    derivatives and zeroed Jacobians due to jnp.sign(0)==0.
-    """
-
-    def test_n2_cartesian(self):
-        """Test N2 optimization in Cartesian coordinates."""
-        atoms = molecule('N2')
-        atoms.calc = EMT()
-        opt = Sella(atoms, order=0, logfile=None)
-        opt.run(fmax=0.01, steps=100)
-        assert opt.converged()
-
-    def test_n2_internal(self):
-        """Test N2 optimization with internal coordinates (TRICs)."""
-        atoms = molecule('N2')
-        atoms.calc = EMT()
-        opt = Sella(atoms, order=0, internal=True, logfile=None)
-        opt.run(fmax=0.01, steps=100)
-        assert opt.converged()


### PR DESCRIPTION
## Summary

Add unit cell optimization for periodic systems and further performance improvements to Sella's internal coordinate engine.

**Cell optimization** (`optimize_cell=True`): simultaneously optimizes atomic positions and unit cell parameters using translation-rotation internal coordinates (TRICs). Supports molecular crystals via rigid fragment mode, Niggli reduction for skewed cells, finite-difference Hessian refinement, and stress-based convergence criteria. Both internal-coordinate (`CellInternalPES`) and Cartesian (`CellCartesianPES`) variants are provided.

**Performance**: 
Key changes:
- GPU-resident Hessian update via torch CUDA (eigh, TS-BFGS, projections stay on device between steps)
- Rotation vmap batching: one JAX dispatch per fragment instead of per-axis (18–30× faster for rotation derivatives)
- SVD → QR replacement for pseudo-inverse and constraint basis computation
- `np.add.at` → `np.bincount` for sparse Hessian scatter (2.5× faster)
- Matmul reassociation throughout to avoid materializing n×n intermediates
- Extensive caching: Jacobian B matrix, basis, constraint Hessian, SparseInternalHessiansSkeleton (index-only data reused across steps), translation vectors, all_positions vstack

**Bug fixes**:
- ASE 3.28 calls `gradient_converged()` instead of `converged()` in its run loop, bypassing Sella's stress convergence check. Added override to delegate correctly.
- `get_Hc` crash when `L=None` due to floating-point non-determinism in `get_x()` — switched to byte-exact state hash for position comparison.
- Dummy atom convergence: dihedral unwrapping (modular arithmetic to avoid 2π jumps), improved h0 diagonal guess, and constraint projection via IC null-space instead of Cartesian min-norm.

### Approaches tried and rejected

Several other approaches were explored to further accelerate Sella without changing behavior. These did not work:

- **Secular equation solver** for eigendecomposition update: approximate eigenvalues weren't accurate enough for TS-BFGS, hurting convergence.
- **Iterative stepper** for the ODE: benchmarked but slower than the dense ODE path at tested system sizes.
- **Block-coordinate optimization** (alternating internal/cell steps): coupling through the Jacobian means joint optimization converges faster.
- **Rank-2 eigenvalue update**: mathematically doesn't work for the TS-BFGS update structure.
- **Separate trust radii** for internal vs cell DOF: reverted in favor of weighted `MaxInternalStep` (`wc` parameter).
- **Sparse `hessian_rdot_vecs`** in ODE: gather-dot-product approach was 9% slower than optimized flat-scatter + dense matvec at large sizes.

## Test plan

- [x] New `test_cell_optimization.py` covers CellCartesianPES, CellInternalPES, rigid fragments, gradient FD checks, Niggli reduction, and convergence
- [x] Benchmarked on 10-system suite (AJEYAQ, BEQGIN, PAPTUX, etc.), 100% convergence rate, ~2-4x faster than BFGS+Frechet baseline