### PR TITLE
Fix IRC converging after 0 steps with ASE >= 3.23

### DIFF
--- a/sella/optimize/irc.py
+++ b/sella/optimize/irc.py
@@ -165,6 +165,8 @@ class IRC(Optimizer):
         self.d1 *= 0.
 
     def converged(self, forces=None):
+        if self.first:
+            return False
         evals = self.pes.H.evals
         return (self.pes.converged(self.fmax)[0]
                 and evals is not None and evals[0] > 0)


### PR DESCRIPTION
ASE >= 3.23 checks converged() before the first step() call. Since IRC starts at a transition state where forces are ~0, this caused immediate convergence. Return False from converged() before the first IRC displacement kick has occurred.

Fixes zadorlab/sella#71