### PR TITLE
Fix Rayleigh-Ritz crash for molecules with very few internal DOFs

### DIFF
--- a/sella/eigensolvers.py
+++ b/sella/eigensolvers.py
@@ -62,7 +62,7 @@ def rayleigh_ritz(A, gamma, P, B=None, v0=None, vref=None, vreftol=0.99,
         AV = AV @ vecs
         V = V @ vecs
         vecs = np.eye(V.shape[1])
-        if V.shape[1] >= maxiter:
+        if V.shape[1] >= min(n, maxiter):
             return lams, V, AV
 
         Ytilde = symmetrize_Y(V, AV, symm=symm)


### PR DESCRIPTION
When the number of free internal DOFs is small (e.g. 1 for a diatomic), the iterative Rayleigh-Ritz eigensolver would try to expand its subspace beyond the full space dimension, producing a zero expansion vector. Normalizing this vector caused NaN, crashing the solver.

Return early when the subspace spans the full space (V.shape[1] >= n), not just when it exceeds maxiter.

Fixes #45 