### PR TITLE
fix: remove upper version constraint on scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires = [
   "wheel",
   "cython >= 0.29.23",
   "numpy >= 1.14.0",
-  "scipy >= 1.1.0, < 1.15",
+  "scipy >= 1.1.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This causes numerous installation problems for the PyPi installation. This makes it to align with the `environment.yml`