### PR TITLE
Complete the legacy unit-test coverage checklist

### DIFF
--- a/tests/integration/test_tip3p_cluster.py
+++ b/tests/integration/test_tip3p_cluster.py
@@ -32,8 +32,6 @@ for offsets in product(*((0, 1),) * 3):
                           (False, 1),
                           ])
 def test_water_dimer(internal, order):
-    internal = True
-    order = 0
     rng = np.random.RandomState(1)
 
     atoms = atoms_ref.copy()

--- a/tests/test_coordinate_transformations.py
+++ b/tests/test_coordinate_transformations.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+from ase.build import molecule
+from ase.calculators.lj import LennardJones
+from ase.calculators.singlepoint import SinglePointCalculator
+
+from sella.internal import Internals
+from sella.peswrapper import InternalPES
+
+
+def _water_internals(atoms):
+    internals = Internals(atoms)
+    internals.find_all_bonds()
+    internals.find_all_angles()
+    internals.find_all_dihedrals()
+    return internals
+
+
+def test_internal_to_cartesian_step_reaches_target_coordinates():
+    atoms = molecule('H2O')
+    atoms.calc = LennardJones()
+    pes = InternalPES(
+        atoms,
+        _water_internals(atoms),
+        auto_find_internals=False,
+        exact_geodesic=True,
+    )
+    initial_positions = atoms.positions.copy()
+    target = pes.get_x() + np.array([0.01, -0.005, 0.02])
+
+    pes.set_x(target)
+
+    residual = pes.wrap_dx(pes.get_x() - target, origin=target)
+    np.testing.assert_allclose(residual, 0.0, atol=2e-6)
+    assert not np.allclose(atoms.positions, initial_positions)
+
+
+def test_cartesian_hessian_converts_to_internal_basis():
+    atoms = molecule('H2O')
+    atoms.calc = SinglePointCalculator(
+        atoms,
+        energy=0.0,
+        forces=np.zeros((len(atoms), 3)),
+    )
+    pes = InternalPES(
+        atoms,
+        _water_internals(atoms),
+        auto_find_internals=False,
+    )
+    rng = np.random.default_rng(11)
+    matrix = rng.normal(size=(3 * len(atoms), 3 * len(atoms)))
+    cartesian_hessian = matrix.T @ matrix
+    jacobian = pes.int.jacobian()
+    inverse_jacobian = np.linalg.pinv(jacobian)
+    expected = inverse_jacobian.T @ cartesian_hessian @ inverse_jacobian
+
+    actual = pes._convert_cartesian_hessian_to_internal(cartesian_hessian)
+
+    np.testing.assert_allclose(actual, expected, atol=1e-10, rtol=1e-10)

--- a/tests/test_hessian_update.py
+++ b/tests/test_hessian_update.py
@@ -4,7 +4,9 @@ from scipy.linalg import eigh, lstsq
 
 from test_utils import get_matrix
 
-from sella.hessian_update import update_H, _MS_TS_BFGS, _MS_PSB
+from sella.hessian_update import (
+    update_H, symmetrize_Y, _MS_TS_BFGS, _MS_PSB,
+)
 
 
 @pytest.mark.parametrize("dim,subdim,method,symm, pd",
@@ -70,3 +72,23 @@ def test_rank_one_ts_bfgs_matches_general_formula():
 
     actual = _MS_TS_BFGS(B, S, Y, lams, vecs)
     np.testing.assert_allclose(actual, expected, atol=1e-12, rtol=1e-12)
+
+
+@pytest.mark.parametrize('method', [0, 1, 2])
+def test_symmetrize_Y_enforces_symmetric_secant_products(method):
+    """Every Y symmetrization method must make S.T @ Y symmetric."""
+    rng = np.random.default_rng(7)
+    S = rng.normal(size=(8, 3))
+    Y = rng.normal(size=(8, 3))
+    original_product = S.T @ Y
+
+    assert not np.allclose(original_product, original_product.T)
+
+    Y_symmetric = symmetrize_Y(S, Y, symm=method)
+    corrected_product = S.T @ Y_symmetric
+
+    np.testing.assert_allclose(
+        corrected_product, corrected_product.T, atol=1e-12
+    )
+    np.testing.assert_array_equal(Y_symmetric[:, 0], Y[:, 0])
+    assert not np.allclose(Y_symmetric, Y)

--- a/tests/test_irc.py
+++ b/tests/test_irc.py
@@ -76,7 +76,9 @@ def test_irc_takes_first_step_from_converged_ts():
     for direction in ('forward', 'reverse'):
         atoms = _ts()
         irc = IRC(atoms, dx=0.1, keep_going=True, logfile=None)
-        irc.run(fmax=0.05, steps=100, direction=direction)
+        converged = irc.run(fmax=0.05, steps=100, direction=direction)
+        assert converged
+        assert irc.converged()
         assert irc.nsteps > 0, f"{direction} IRC took no steps"
         assert np.abs(atoms.get_positions() - x0).max() > 1e-3, \
             f"{direction} IRC did not leave the TS"


### PR DESCRIPTION
## Summary

Complete the remaining meaningful test coverage requested in Issue #3:

- Directly test all three Y-matrix symmetrization methods with a nontrivial asymmetric secant product.
- Test an internal-coordinate step reaching its target Cartesian geometry.
- Test Cartesian-to-internal Hessian conversion against the explicit pseudoinverse formula.
- Require the IRC integration test to actually converge in both directions.
- Restore the intended TIP3P parameter matrix; the test previously overwrote every case with `internal=True, order=0`.

The old force-matching item is no longer applicable because that feature was removed from Sella.

## Testing

- `354 passed`

Related to #3.